### PR TITLE
feat: add TanStack Query API client and system endpoint #4

### DIFF
--- a/src/main/resources/admin/tools/main/main.ts
+++ b/src/main/resources/admin/tools/main/main.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from '@enonic-types/core';
 import { render } from '/lib/mustache';
 import { extensionUrl, getToolUrl } from '/lib/xp/admin';
 import { getUser } from '/lib/xp/auth';
-import { assetUrl, serviceUrl } from '/lib/xp/portal';
+import { apiUrl, assetUrl } from '/lib/xp/portal';
 
 type DataKitConfig = {
     appId: string;
@@ -23,7 +23,7 @@ function buildConfig(): DataKitConfig {
         appId: app.name,
         assetsUri: assetUrl({ path: '' }),
         toolUri: getToolUrl(app.name, 'main'),
-        apiUri: serviceUrl({ service: 'api', type: 'server' }),
+        apiUri: apiUrl({ api: 'system', type: 'server' }).replace(/\/system\/?$/, ''),
         launcherUri: extensionUrl({
             application: 'com.enonic.xp.app.main',
             extension: 'launcher',

--- a/src/main/resources/admin/tools/main/main.yml
+++ b/src/main/resources/admin/tools/main/main.yml
@@ -10,3 +10,4 @@ apis:
   - "admin:extension"
   - "admin:event"
   - "admin:status"
+  - "system"

--- a/src/main/resources/apis/system/system.ts
+++ b/src/main/resources/apis/system/system.ts
@@ -1,0 +1,22 @@
+import type { Request, Response } from '@enonic-types/core';
+import { getVersion } from '/lib/xp/admin';
+import { jsonResponse, requireAdmin } from '../../lib/api';
+
+type SystemInfo = {
+    xpVersion: string;
+    appVersion: string;
+    appName: string;
+};
+
+export function get(_req: Request): Response {
+    const forbidden = requireAdmin();
+    if (forbidden != null) return forbidden;
+
+    const info: SystemInfo = {
+        xpVersion: getVersion(),
+        appVersion: app.version,
+        appName: app.name,
+    };
+
+    return jsonResponse(info);
+}

--- a/src/main/resources/apis/system/system.xml
+++ b/src/main/resources/apis/system/system.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <allow>
+        <role>system.admin</role>
+    </allow>
+</api>

--- a/src/main/resources/assets/js/app.tsx
+++ b/src/main/resources/assets/js/app.tsx
@@ -6,8 +6,20 @@ import { ThemeProvider } from './components/theme-provider';
 import { getConfig } from './lib/config';
 import { createAppRouter } from './router';
 
+const STALE_TIME_MS = 30_000;
+const MAX_RETRIES = 1;
+
 const config = getConfig();
-const queryClient = new QueryClient();
+
+const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            staleTime: STALE_TIME_MS,
+            retry: MAX_RETRIES,
+        },
+    },
+});
+
 const router = createAppRouter({ queryClient, config });
 
 const APP_NAME = 'App';

--- a/src/main/resources/assets/js/lib/api/client.ts
+++ b/src/main/resources/assets/js/lib/api/client.ts
@@ -1,0 +1,53 @@
+import type { ApiError, ApiResponse } from '../../types/api';
+import { getConfig } from '../config';
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+type ApiFetchOptions = {
+    method?: HttpMethod;
+    body?: unknown;
+    params?: Record<string, string>;
+};
+
+function buildUrl(endpoint: string, params?: Record<string, string>): string {
+    const { apiUri } = getConfig();
+    const url = new URL(`${apiUri}${endpoint}`, window.location.origin);
+
+    if (params != null) {
+        for (const [key, value] of Object.entries(params)) {
+            url.searchParams.set(key, value);
+        }
+    }
+
+    return url.toString();
+}
+
+export async function apiFetch<T>(endpoint: string, options: ApiFetchOptions = {}): Promise<T> {
+    const { method = 'GET', body, params } = options;
+    const url = buildUrl(endpoint, params);
+
+    const headers: Record<string, string> = {
+        Accept: 'application/json',
+    };
+
+    if (body != null) {
+        headers['Content-Type'] = 'application/json';
+    }
+
+    const response = await fetch(url, {
+        method,
+        headers,
+        body: body != null ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+        const error: ApiError = await response.json().catch(() => ({
+            status: response.status,
+            message: response.statusText,
+        }));
+        throw error;
+    }
+
+    const envelope: ApiResponse<T> = await response.json();
+    return envelope.data;
+}

--- a/src/main/resources/assets/js/lib/api/system.ts
+++ b/src/main/resources/assets/js/lib/api/system.ts
@@ -1,0 +1,19 @@
+import { queryOptions } from '@tanstack/react-query';
+import { apiFetch } from './client';
+
+type SystemInfo = {
+    xpVersion: string;
+    appVersion: string;
+    appName: string;
+};
+
+export function fetchSystemInfo(): Promise<SystemInfo> {
+    return apiFetch<SystemInfo>('/system');
+}
+
+export function systemInfoQueryOptions() {
+    return queryOptions({
+        queryKey: ['system', 'info'],
+        queryFn: fetchSystemInfo,
+    });
+}

--- a/src/main/resources/assets/js/routes/__root.tsx
+++ b/src/main/resources/assets/js/routes/__root.tsx
@@ -13,6 +13,14 @@ const TanStackRouterDevtools = import.meta.env.PROD
           })),
       );
 
+const ReactQueryDevtools = import.meta.env.PROD
+    ? () => null
+    : lazy(() =>
+          import('@tanstack/react-query-devtools').then((mod) => ({
+              default: mod.ReactQueryDevtools,
+          })),
+      );
+
 const ROOT_LAYOUT_NAME = 'RootLayout';
 
 const RootLayout = (): ReactElement => {
@@ -27,6 +35,9 @@ const RootLayout = (): ReactElement => {
             </div>
             <Suspense>
                 <TanStackRouterDevtools position="bottom-right" />
+            </Suspense>
+            <Suspense>
+                <ReactQueryDevtools buttonPosition="bottom-left" />
             </Suspense>
         </div>
     );

--- a/src/main/resources/assets/js/routes/system.tsx
+++ b/src/main/resources/assets/js/routes/system.tsx
@@ -1,15 +1,27 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import type { ReactElement } from 'react';
+import { systemInfoQueryOptions } from '../lib/api/system';
 
 const SYSTEM_PAGE_NAME = 'SystemPage';
 
 const SystemPage = (): ReactElement => {
+    const { data: systemInfo } = useSuspenseQuery(systemInfoQueryOptions());
+
     return (
         <div data-component={SYSTEM_PAGE_NAME} className="p-6">
             <h2 className="font-semibold text-2xl">System</h2>
             <p className="mt-2 text-muted-foreground">
                 View system information here.
             </p>
+            <dl className="mt-6 grid max-w-md grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+                <dt className="font-medium text-muted-foreground">XP Version</dt>
+                <dd>{systemInfo.xpVersion}</dd>
+                <dt className="font-medium text-muted-foreground">App Version</dt>
+                <dd>{systemInfo.appVersion}</dd>
+                <dt className="font-medium text-muted-foreground">App Name</dt>
+                <dd className="font-mono text-xs">{systemInfo.appName}</dd>
+            </dl>
         </div>
     );
 };
@@ -17,5 +29,7 @@ const SystemPage = (): ReactElement => {
 SystemPage.displayName = SYSTEM_PAGE_NAME;
 
 export const Route = createFileRoute('/system')({
+    loader: ({ context: { queryClient } }) =>
+        queryClient.ensureQueryData(systemInfoQueryOptions()),
     component: SystemPage,
 });

--- a/src/main/resources/lib/api.ts
+++ b/src/main/resources/lib/api.ts
@@ -1,0 +1,39 @@
+import type { Request, Response } from '@enonic-types/core';
+import { hasRole } from '/lib/xp/auth';
+
+//
+// * Response Helpers
+//
+
+export function jsonResponse<T>(data: T, status = 200): Response {
+    return {
+        status,
+        contentType: 'application/json',
+        body: JSON.stringify({ data }),
+    };
+}
+
+export function errorResponse(status: number, message: string, code?: string): Response {
+    return {
+        status,
+        contentType: 'application/json',
+        body: JSON.stringify({ status, message, code }),
+    };
+}
+
+//
+// * Request Helpers
+//
+
+export function getParam(req: Request, name: string): string | undefined {
+    const value = req.params?.[name];
+    if (value == null) return undefined;
+    return Array.isArray(value) ? value[0] : value;
+}
+
+export function requireAdmin(): Response | undefined {
+    if (!hasRole('system.admin')) {
+        return errorResponse(403, 'Admin role required', 'FORBIDDEN');
+    }
+    return undefined;
+}

--- a/src/main/resources/types/xp-admin-ext.d.ts
+++ b/src/main/resources/types/xp-admin-ext.d.ts
@@ -7,4 +7,6 @@ declare module '/lib/xp/admin' {
         extension: string;
         params?: Record<string, string>;
     }): string;
+
+    export function getVersion(): string;
 }

--- a/src/main/resources/types/xp-portal-ext.d.ts
+++ b/src/main/resources/types/xp-portal-ext.d.ts
@@ -1,0 +1,12 @@
+// ? Augmentation for XP 8 portal API. Remove when @enonic-types/lib-portal publishes XP 8 types.
+export {};
+
+declare module '/lib/xp/portal' {
+    export function apiUrl(params: {
+        api: string;
+        type?: 'server' | 'absolute' | 'websocket';
+        params?: Record<string, string | string[]>;
+        path?: string | string[];
+        baseUrl?: string;
+    }): string;
+}

--- a/src/test/lib/api.test.ts
+++ b/src/test/lib/api.test.ts
@@ -1,0 +1,66 @@
+import type { Request } from '@enonic-types/core';
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('/lib/xp/auth', () => ({
+    hasRole: vi.fn(),
+}));
+
+import { errorResponse, getParam, jsonResponse } from '../../main/resources/lib/api';
+
+describe('jsonResponse', () => {
+    test('wraps data in ApiResponse envelope', () => {
+        const result = jsonResponse({ name: 'test' });
+        expect(result.status).toBe(200);
+        expect(result.contentType).toBe('application/json');
+        expect(JSON.parse(result.body as string)).toEqual({ data: { name: 'test' } });
+    });
+
+    test('uses custom status code', () => {
+        const result = jsonResponse('created', 201);
+        expect(result.status).toBe(201);
+        expect(JSON.parse(result.body as string)).toEqual({ data: 'created' });
+    });
+});
+
+describe('errorResponse', () => {
+    test('returns error with status and message', () => {
+        const result = errorResponse(404, 'Not found');
+        expect(result.status).toBe(404);
+        expect(result.contentType).toBe('application/json');
+        expect(JSON.parse(result.body as string)).toEqual({
+            status: 404,
+            message: 'Not found',
+        });
+    });
+
+    test('includes optional error code', () => {
+        const result = errorResponse(403, 'Forbidden', 'FORBIDDEN');
+        expect(JSON.parse(result.body as string)).toEqual({
+            status: 403,
+            message: 'Forbidden',
+            code: 'FORBIDDEN',
+        });
+    });
+});
+
+describe('getParam', () => {
+    test('returns string parameter', () => {
+        const req = { params: { name: 'value' } } as unknown as Request;
+        expect(getParam(req, 'name')).toBe('value');
+    });
+
+    test('returns first element of array parameter', () => {
+        const req = { params: { name: ['first', 'second'] } } as unknown as Request;
+        expect(getParam(req, 'name')).toBe('first');
+    });
+
+    test('returns undefined for missing parameter', () => {
+        const req = { params: {} } as unknown as Request;
+        expect(getParam(req, 'missing')).toBeUndefined();
+    });
+
+    test('returns undefined when params is undefined', () => {
+        const req = {} as unknown as Request;
+        expect(getParam(req, 'name')).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Added server-side API helpers (`lib/api.ts`) with `jsonResponse`, `errorResponse`, `getParam`, and `requireAdmin`
Created `apis/system/` endpoint returning XP version, app version, and app name
Added `apiUrl` type augmentation for XP 8 portal API and `getVersion` to admin API types
Updated admin tool controller to derive API base URL via `apiUrl()` instead of `serviceUrl()`
Registered `system` API in admin tool descriptor
Created typed frontend `apiFetch` client with response envelope unwrapping and error handling
Added `systemInfoQueryOptions` using TanStack Query `queryOptions()` pattern
Configured `QueryClient` defaults with 30s `staleTime` and 1 retry
Added lazy-loaded React Query devtools in dev mode
Wired system route with `useSuspenseQuery` and route loader prefetching
Added unit tests for server-side API helpers

https://claude.ai/code/session_01YbBvSR9tvxCFaj6nbpGe9g