### PR TITLE
feat: add shadcn/ui base component library #5

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "@radix-ui/react-dialog": "~1.1.15",
         "@radix-ui/react-dropdown-menu": "~2.1.16",
         "@radix-ui/react-label": "~2.1.8",
+        "@radix-ui/react-progress": "~1.1.8",
         "@radix-ui/react-scroll-area": "~1.2.10",
         "@radix-ui/react-select": "~2.2.6",
         "@radix-ui/react-separator": "~1.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ~2.1.8
         version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-progress':
+        specifier: ~1.1.8
+        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-scroll-area':
         specifier: ~1.2.10
         version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -634,6 +637,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.3':
+    resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dialog@1.1.15':
     resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
     peerDependencies:
@@ -793,6 +805,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.8':
+    resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2563,6 +2588,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-context@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -2728,6 +2759,16 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-progress@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:

--- a/src/main/resources/assets/js/app.tsx
+++ b/src/main/resources/assets/js/app.tsx
@@ -3,6 +3,8 @@ import { RouterProvider } from '@tanstack/react-router';
 import type { ReactElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { ThemeProvider } from './components/theme-provider';
+import { Toaster } from './components/ui/sonner';
+import { TooltipProvider } from './components/ui/tooltip';
 import { getConfig } from './lib/config';
 import { createAppRouter } from './router';
 
@@ -28,8 +30,11 @@ const App = (): ReactElement => {
     return (
         <ThemeProvider>
             <QueryClientProvider client={queryClient}>
-                <RouterProvider router={router} />
+                <TooltipProvider>
+                    <RouterProvider router={router} />
+                </TooltipProvider>
             </QueryClientProvider>
+            <Toaster />
         </ThemeProvider>
     );
 };

--- a/src/main/resources/assets/js/components/ui/alert-dialog.tsx
+++ b/src/main/resources/assets/js/components/ui/alert-dialog.tsx
@@ -1,0 +1,214 @@
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+import { buttonVariants } from './button';
+
+//
+// * AlertDialog
+//
+
+export const AlertDialog = AlertDialogPrimitive.Root;
+
+//
+// * AlertDialogTrigger
+//
+
+export const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+//
+// * AlertDialogPortal
+//
+
+export const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+//
+// * AlertDialogOverlay
+//
+
+const ALERT_DIALOG_OVERLAY_NAME = 'AlertDialogOverlay';
+
+export const AlertDialogOverlay = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof AlertDialogPrimitive.Overlay>): ReactElement => {
+    return (
+        <AlertDialogPrimitive.Overlay
+            ref={ref}
+            className={cn(
+                'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 data-[state=closed]:animate-out data-[state=open]:animate-in',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+AlertDialogOverlay.displayName = ALERT_DIALOG_OVERLAY_NAME;
+
+//
+// * AlertDialogContent
+//
+
+const ALERT_DIALOG_CONTENT_NAME = 'AlertDialogContent';
+
+export const AlertDialogContent = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof AlertDialogPrimitive.Content>): ReactElement => {
+    return (
+        <AlertDialogPortal>
+            <AlertDialogOverlay />
+            <AlertDialogPrimitive.Content
+                ref={ref}
+                data-component={ALERT_DIALOG_CONTENT_NAME}
+                className={cn(
+                    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg',
+                    className,
+                )}
+                {...props}
+            />
+        </AlertDialogPortal>
+    );
+};
+
+AlertDialogContent.displayName = ALERT_DIALOG_CONTENT_NAME;
+
+//
+// * AlertDialogHeader
+//
+
+const ALERT_DIALOG_HEADER_NAME = 'AlertDialogHeader';
+
+export const AlertDialogHeader = ({
+    className,
+    ...props
+}: ComponentProps<'div'>): ReactElement => {
+    return (
+        <div
+            className={cn(
+                'flex flex-col space-y-2 text-center sm:text-left',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+AlertDialogHeader.displayName = ALERT_DIALOG_HEADER_NAME;
+
+//
+// * AlertDialogFooter
+//
+
+const ALERT_DIALOG_FOOTER_NAME = 'AlertDialogFooter';
+
+export const AlertDialogFooter = ({
+    className,
+    ...props
+}: ComponentProps<'div'>): ReactElement => {
+    return (
+        <div
+            className={cn(
+                'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+AlertDialogFooter.displayName = ALERT_DIALOG_FOOTER_NAME;
+
+//
+// * AlertDialogTitle
+//
+
+const ALERT_DIALOG_TITLE_NAME = 'AlertDialogTitle';
+
+export const AlertDialogTitle = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof AlertDialogPrimitive.Title>): ReactElement => {
+    return (
+        <AlertDialogPrimitive.Title
+            ref={ref}
+            className={cn('font-semibold text-lg', className)}
+            {...props}
+        />
+    );
+};
+
+AlertDialogTitle.displayName = ALERT_DIALOG_TITLE_NAME;
+
+//
+// * AlertDialogDescription
+//
+
+const ALERT_DIALOG_DESCRIPTION_NAME = 'AlertDialogDescription';
+
+export const AlertDialogDescription = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof AlertDialogPrimitive.Description>): ReactElement => {
+    return (
+        <AlertDialogPrimitive.Description
+            ref={ref}
+            className={cn('text-muted-foreground text-sm', className)}
+            {...props}
+        />
+    );
+};
+
+AlertDialogDescription.displayName = ALERT_DIALOG_DESCRIPTION_NAME;
+
+//
+// * AlertDialogAction
+//
+
+const ALERT_DIALOG_ACTION_NAME = 'AlertDialogAction';
+
+export const AlertDialogAction = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof AlertDialogPrimitive.Action>): ReactElement => {
+    return (
+        <AlertDialogPrimitive.Action
+            ref={ref}
+            className={cn(buttonVariants(), className)}
+            {...props}
+        />
+    );
+};
+
+AlertDialogAction.displayName = ALERT_DIALOG_ACTION_NAME;
+
+//
+// * AlertDialogCancel
+//
+
+const ALERT_DIALOG_CANCEL_NAME = 'AlertDialogCancel';
+
+export const AlertDialogCancel = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof AlertDialogPrimitive.Cancel>): ReactElement => {
+    return (
+        <AlertDialogPrimitive.Cancel
+            ref={ref}
+            className={cn(
+                buttonVariants({ variant: 'outline' }),
+                'mt-2 sm:mt-0',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+AlertDialogCancel.displayName = ALERT_DIALOG_CANCEL_NAME;

--- a/src/main/resources/assets/js/components/ui/badge.tsx
+++ b/src/main/resources/assets/js/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+const badgeVariants = cva(
+    'inline-flex items-center rounded-full border px-2.5 py-0.5 font-semibold text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+    {
+        variants: {
+            variant: {
+                default:
+                    'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
+                secondary:
+                    'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+                destructive:
+                    'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
+                outline: 'text-foreground',
+            },
+        },
+        defaultVariants: {
+            variant: 'default',
+        },
+    },
+);
+
+export type BadgeProps = ComponentProps<'div'> &
+    VariantProps<typeof badgeVariants>;
+
+const BADGE_NAME = 'Badge';
+
+export const Badge = ({
+    className,
+    variant,
+    ...props
+}: BadgeProps): ReactElement => {
+    return (
+        <div
+            data-component={BADGE_NAME}
+            className={cn(badgeVariants({ variant }), className)}
+            {...props}
+        />
+    );
+};
+
+Badge.displayName = BADGE_NAME;
+
+export { badgeVariants };

--- a/src/main/resources/assets/js/components/ui/button.tsx
+++ b/src/main/resources/assets/js/components/ui/button.tsx
@@ -1,0 +1,65 @@
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+    'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium text-sm ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+    {
+        variants: {
+            variant: {
+                default:
+                    'bg-primary text-primary-foreground hover:bg-primary/90',
+                destructive:
+                    'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+                outline:
+                    'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+                secondary:
+                    'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+                ghost: 'hover:bg-accent hover:text-accent-foreground',
+                link: 'text-primary underline-offset-4 hover:underline',
+            },
+            size: {
+                default: 'h-10 px-4 py-2',
+                sm: 'h-9 rounded-md px-3',
+                lg: 'h-11 rounded-md px-8',
+                icon: 'size-10',
+            },
+        },
+        defaultVariants: {
+            variant: 'default',
+            size: 'default',
+        },
+    },
+);
+
+export type ButtonProps = ComponentProps<'button'> &
+    VariantProps<typeof buttonVariants> & {
+        asChild?: boolean;
+    };
+
+const BUTTON_NAME = 'Button';
+
+export const Button = ({
+    ref,
+    className,
+    variant,
+    size,
+    asChild = false,
+    ...props
+}: ButtonProps): ReactElement => {
+    const Comp = asChild ? Slot : 'button';
+
+    return (
+        <Comp
+            ref={ref}
+            data-component={BUTTON_NAME}
+            className={cn(buttonVariants({ variant, size }), className)}
+            {...props}
+        />
+    );
+};
+
+Button.displayName = BUTTON_NAME;
+
+export { buttonVariants };

--- a/src/main/resources/assets/js/components/ui/card.tsx
+++ b/src/main/resources/assets/js/components/ui/card.tsx
@@ -1,0 +1,141 @@
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+//
+// * Card
+//
+
+const CARD_NAME = 'Card';
+
+export const Card = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'div'>): ReactElement => {
+    return (
+        <div
+            ref={ref}
+            data-component={CARD_NAME}
+            className={cn(
+                'rounded-lg border bg-card text-card-foreground shadow-sm',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+Card.displayName = CARD_NAME;
+
+//
+// * CardHeader
+//
+
+const CARD_HEADER_NAME = 'CardHeader';
+
+export const CardHeader = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'div'>): ReactElement => {
+    return (
+        <div
+            ref={ref}
+            className={cn('flex flex-col space-y-1.5 p-6', className)}
+            {...props}
+        />
+    );
+};
+
+CardHeader.displayName = CARD_HEADER_NAME;
+
+//
+// * CardTitle
+//
+
+const CARD_TITLE_NAME = 'CardTitle';
+
+export const CardTitle = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'h3'>): ReactElement => {
+    return (
+        <h3
+            ref={ref}
+            className={cn(
+                'font-semibold text-2xl leading-none tracking-tight',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+CardTitle.displayName = CARD_TITLE_NAME;
+
+//
+// * CardDescription
+//
+
+const CARD_DESCRIPTION_NAME = 'CardDescription';
+
+export const CardDescription = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'p'>): ReactElement => {
+    return (
+        <p
+            ref={ref}
+            className={cn('text-muted-foreground text-sm', className)}
+            {...props}
+        />
+    );
+};
+
+CardDescription.displayName = CARD_DESCRIPTION_NAME;
+
+//
+// * CardContent
+//
+
+const CARD_CONTENT_NAME = 'CardContent';
+
+export const CardContent = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'div'>): ReactElement => {
+    return (
+        <div
+            ref={ref}
+            className={cn('p-6 pt-0', className)}
+            {...props}
+        />
+    );
+};
+
+CardContent.displayName = CARD_CONTENT_NAME;
+
+//
+// * CardFooter
+//
+
+const CARD_FOOTER_NAME = 'CardFooter';
+
+export const CardFooter = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'div'>): ReactElement => {
+    return (
+        <div
+            ref={ref}
+            className={cn('flex items-center p-6 pt-0', className)}
+            {...props}
+        />
+    );
+};
+
+CardFooter.displayName = CARD_FOOTER_NAME;

--- a/src/main/resources/assets/js/components/ui/checkbox.tsx
+++ b/src/main/resources/assets/js/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
+import { Check } from 'lucide-react';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+const CHECKBOX_NAME = 'Checkbox';
+
+export const Checkbox = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof CheckboxPrimitive.Root>): ReactElement => {
+    return (
+        <CheckboxPrimitive.Root
+            ref={ref}
+            data-component={CHECKBOX_NAME}
+            className={cn(
+                'peer size-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+                className,
+            )}
+            {...props}
+        >
+            <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+                <Check className="size-4" />
+            </CheckboxPrimitive.Indicator>
+        </CheckboxPrimitive.Root>
+    );
+};
+
+Checkbox.displayName = CHECKBOX_NAME;

--- a/src/main/resources/assets/js/components/ui/confirm-dialog.tsx
+++ b/src/main/resources/assets/js/components/ui/confirm-dialog.tsx
@@ -1,0 +1,70 @@
+import type { ReactElement, ReactNode } from 'react';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from './alert-dialog';
+import { buttonVariants } from './button';
+
+export type ConfirmDialogProps = {
+    title: string;
+    description: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    variant?: 'default' | 'destructive';
+    onConfirm: () => void;
+    onCancel?: () => void;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children?: ReactNode;
+};
+
+const CONFIRM_DIALOG_NAME = 'ConfirmDialog';
+
+export const ConfirmDialog = ({
+    title,
+    description,
+    confirmLabel = 'Confirm',
+    cancelLabel = 'Cancel',
+    variant = 'default',
+    onConfirm,
+    onCancel,
+    open,
+    onOpenChange,
+    children,
+}: ConfirmDialogProps): ReactElement => {
+    return (
+        <AlertDialog open={open} onOpenChange={onOpenChange}>
+            {children != null && (
+                <AlertDialogTrigger asChild>{children}</AlertDialogTrigger>
+            )}
+            <AlertDialogContent data-component={CONFIRM_DIALOG_NAME}>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>{title}</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        {description}
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel onClick={onCancel}>
+                        {cancelLabel}
+                    </AlertDialogCancel>
+                    <AlertDialogAction
+                        onClick={onConfirm}
+                        className={buttonVariants({ variant })}
+                    >
+                        {confirmLabel}
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+};
+
+ConfirmDialog.displayName = CONFIRM_DIALOG_NAME;

--- a/src/main/resources/assets/js/components/ui/dialog.tsx
+++ b/src/main/resources/assets/js/components/ui/dialog.tsx
@@ -1,0 +1,182 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+//
+// * Dialog
+//
+
+export const Dialog = DialogPrimitive.Root;
+
+//
+// * DialogTrigger
+//
+
+export const DialogTrigger = DialogPrimitive.Trigger;
+
+//
+// * DialogClose
+//
+
+export const DialogClose = DialogPrimitive.Close;
+
+//
+// * DialogPortal
+//
+
+export const DialogPortal = DialogPrimitive.Portal;
+
+//
+// * DialogOverlay
+//
+
+const DIALOG_OVERLAY_NAME = 'DialogOverlay';
+
+export const DialogOverlay = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof DialogPrimitive.Overlay>): ReactElement => {
+    return (
+        <DialogPrimitive.Overlay
+            ref={ref}
+            className={cn(
+                'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 data-[state=closed]:animate-out data-[state=open]:animate-in',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+DialogOverlay.displayName = DIALOG_OVERLAY_NAME;
+
+//
+// * DialogContent
+//
+
+const DIALOG_CONTENT_NAME = 'DialogContent';
+
+export const DialogContent = ({
+    ref,
+    className,
+    children,
+    ...props
+}: ComponentProps<typeof DialogPrimitive.Content>): ReactElement => {
+    return (
+        <DialogPortal>
+            <DialogOverlay />
+            <DialogPrimitive.Content
+                ref={ref}
+                data-component={DIALOG_CONTENT_NAME}
+                className={cn(
+                    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg',
+                    className,
+                )}
+                {...props}
+            >
+                {children}
+                <DialogPrimitive.Close className="absolute top-4 right-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+                    <X className="size-4" />
+                    <span className="sr-only">Close</span>
+                </DialogPrimitive.Close>
+            </DialogPrimitive.Content>
+        </DialogPortal>
+    );
+};
+
+DialogContent.displayName = DIALOG_CONTENT_NAME;
+
+//
+// * DialogHeader
+//
+
+const DIALOG_HEADER_NAME = 'DialogHeader';
+
+export const DialogHeader = ({
+    className,
+    ...props
+}: ComponentProps<'div'>): ReactElement => {
+    return (
+        <div
+            className={cn(
+                'flex flex-col space-y-1.5 text-center sm:text-left',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+DialogHeader.displayName = DIALOG_HEADER_NAME;
+
+//
+// * DialogFooter
+//
+
+const DIALOG_FOOTER_NAME = 'DialogFooter';
+
+export const DialogFooter = ({
+    className,
+    ...props
+}: ComponentProps<'div'>): ReactElement => {
+    return (
+        <div
+            className={cn(
+                'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+DialogFooter.displayName = DIALOG_FOOTER_NAME;
+
+//
+// * DialogTitle
+//
+
+const DIALOG_TITLE_NAME = 'DialogTitle';
+
+export const DialogTitle = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof DialogPrimitive.Title>): ReactElement => {
+    return (
+        <DialogPrimitive.Title
+            ref={ref}
+            className={cn(
+                'font-semibold text-lg leading-none tracking-tight',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+DialogTitle.displayName = DIALOG_TITLE_NAME;
+
+//
+// * DialogDescription
+//
+
+const DIALOG_DESCRIPTION_NAME = 'DialogDescription';
+
+export const DialogDescription = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof DialogPrimitive.Description>): ReactElement => {
+    return (
+        <DialogPrimitive.Description
+            ref={ref}
+            className={cn('text-muted-foreground text-sm', className)}
+            {...props}
+        />
+    );
+};
+
+DialogDescription.displayName = DIALOG_DESCRIPTION_NAME;

--- a/src/main/resources/assets/js/components/ui/dropdown-menu.tsx
+++ b/src/main/resources/assets/js/components/ui/dropdown-menu.tsx
@@ -1,0 +1,276 @@
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { Check, ChevronRight, Circle } from 'lucide-react';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+//
+// * DropdownMenu
+//
+
+export const DropdownMenu = DropdownMenuPrimitive.Root;
+
+//
+// * DropdownMenuTrigger
+//
+
+export const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+//
+// * DropdownMenuGroup
+//
+
+export const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+//
+// * DropdownMenuPortal
+//
+
+export const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+//
+// * DropdownMenuSub
+//
+
+export const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+//
+// * DropdownMenuRadioGroup
+//
+
+export const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+//
+// * DropdownMenuSubTrigger
+//
+
+const DROPDOWN_MENU_SUB_TRIGGER_NAME = 'DropdownMenuSubTrigger';
+
+export const DropdownMenuSubTrigger = ({
+    ref,
+    className,
+    inset,
+    children,
+    ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+}): ReactElement => {
+    return (
+        <DropdownMenuPrimitive.SubTrigger
+            ref={ref}
+            className={cn(
+                'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent',
+                inset && 'pl-8',
+                className,
+            )}
+            {...props}
+        >
+            {children}
+            <ChevronRight className="ml-auto size-4" />
+        </DropdownMenuPrimitive.SubTrigger>
+    );
+};
+
+DropdownMenuSubTrigger.displayName = DROPDOWN_MENU_SUB_TRIGGER_NAME;
+
+//
+// * DropdownMenuSubContent
+//
+
+const DROPDOWN_MENU_SUB_CONTENT_NAME = 'DropdownMenuSubContent';
+
+export const DropdownMenuSubContent = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.SubContent>): ReactElement => {
+    return (
+        <DropdownMenuPrimitive.SubContent
+            ref={ref}
+            className={cn(
+                'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border bg-card p-1 text-card-foreground shadow-lg data-[state=closed]:animate-out data-[state=open]:animate-in',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+DropdownMenuSubContent.displayName = DROPDOWN_MENU_SUB_CONTENT_NAME;
+
+//
+// * DropdownMenuContent
+//
+
+const DROPDOWN_MENU_CONTENT_NAME = 'DropdownMenuContent';
+
+export const DropdownMenuContent = ({
+    ref,
+    className,
+    sideOffset = 4,
+    ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Content>): ReactElement => {
+    return (
+        <DropdownMenuPrimitive.Portal>
+            <DropdownMenuPrimitive.Content
+                ref={ref}
+                data-component={DROPDOWN_MENU_CONTENT_NAME}
+                sideOffset={sideOffset}
+                className={cn(
+                    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border bg-card p-1 text-card-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in',
+                    className,
+                )}
+                {...props}
+            />
+        </DropdownMenuPrimitive.Portal>
+    );
+};
+
+DropdownMenuContent.displayName = DROPDOWN_MENU_CONTENT_NAME;
+
+//
+// * DropdownMenuItem
+//
+
+const DROPDOWN_MENU_ITEM_NAME = 'DropdownMenuItem';
+
+export const DropdownMenuItem = ({
+    ref,
+    className,
+    inset,
+    ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+}): ReactElement => {
+    return (
+        <DropdownMenuPrimitive.Item
+            ref={ref}
+            className={cn(
+                'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+                inset && 'pl-8',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+DropdownMenuItem.displayName = DROPDOWN_MENU_ITEM_NAME;
+
+//
+// * DropdownMenuCheckboxItem
+//
+
+const DROPDOWN_MENU_CHECKBOX_ITEM_NAME = 'DropdownMenuCheckboxItem';
+
+export const DropdownMenuCheckboxItem = ({
+    ref,
+    className,
+    children,
+    checked,
+    ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>): ReactElement => {
+    return (
+        <DropdownMenuPrimitive.CheckboxItem
+            ref={ref}
+            className={cn(
+                'relative flex cursor-default select-none items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+                className,
+            )}
+            checked={checked}
+            {...props}
+        >
+            <span className="absolute left-2 flex size-3.5 items-center justify-center">
+                <DropdownMenuPrimitive.ItemIndicator>
+                    <Check className="size-4" />
+                </DropdownMenuPrimitive.ItemIndicator>
+            </span>
+            {children}
+        </DropdownMenuPrimitive.CheckboxItem>
+    );
+};
+
+DropdownMenuCheckboxItem.displayName = DROPDOWN_MENU_CHECKBOX_ITEM_NAME;
+
+//
+// * DropdownMenuRadioItem
+//
+
+const DROPDOWN_MENU_RADIO_ITEM_NAME = 'DropdownMenuRadioItem';
+
+export const DropdownMenuRadioItem = ({
+    ref,
+    className,
+    children,
+    ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.RadioItem>): ReactElement => {
+    return (
+        <DropdownMenuPrimitive.RadioItem
+            ref={ref}
+            className={cn(
+                'relative flex cursor-default select-none items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+                className,
+            )}
+            {...props}
+        >
+            <span className="absolute left-2 flex size-3.5 items-center justify-center">
+                <DropdownMenuPrimitive.ItemIndicator>
+                    <Circle className="size-2 fill-current" />
+                </DropdownMenuPrimitive.ItemIndicator>
+            </span>
+            {children}
+        </DropdownMenuPrimitive.RadioItem>
+    );
+};
+
+DropdownMenuRadioItem.displayName = DROPDOWN_MENU_RADIO_ITEM_NAME;
+
+//
+// * DropdownMenuLabel
+//
+
+const DROPDOWN_MENU_LABEL_NAME = 'DropdownMenuLabel';
+
+export const DropdownMenuLabel = ({
+    ref,
+    className,
+    inset,
+    ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+}): ReactElement => {
+    return (
+        <DropdownMenuPrimitive.Label
+            ref={ref}
+            className={cn(
+                'px-2 py-1.5 font-semibold text-sm',
+                inset && 'pl-8',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+DropdownMenuLabel.displayName = DROPDOWN_MENU_LABEL_NAME;
+
+//
+// * DropdownMenuSeparator
+//
+
+const DROPDOWN_MENU_SEPARATOR_NAME = 'DropdownMenuSeparator';
+
+export const DropdownMenuSeparator = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Separator>): ReactElement => {
+    return (
+        <DropdownMenuPrimitive.Separator
+            ref={ref}
+            className={cn('-mx-1 my-1 h-px bg-muted', className)}
+            {...props}
+        />
+    );
+};
+
+DropdownMenuSeparator.displayName = DROPDOWN_MENU_SEPARATOR_NAME;

--- a/src/main/resources/assets/js/components/ui/empty-state.tsx
+++ b/src/main/resources/assets/js/components/ui/empty-state.tsx
@@ -1,0 +1,42 @@
+import type { LucideIcon } from 'lucide-react';
+import type { ReactElement, ReactNode } from 'react';
+import { cn } from '../../lib/utils';
+
+export type EmptyStateProps = {
+    icon: LucideIcon;
+    title: string;
+    description: string;
+    action?: ReactNode;
+    className?: string;
+};
+
+const EMPTY_STATE_NAME = 'EmptyState';
+
+export const EmptyState = ({
+    icon: Icon,
+    title,
+    description,
+    action,
+    className,
+}: EmptyStateProps): ReactElement => {
+    return (
+        <div
+            data-component={EMPTY_STATE_NAME}
+            className={cn(
+                'flex flex-col items-center justify-center py-12 text-center',
+                className,
+            )}
+        >
+            <Icon className="mb-4 size-12 text-muted-foreground" />
+            <h3 className="mb-1 font-semibold text-foreground text-lg">
+                {title}
+            </h3>
+            <p className="mb-4 max-w-sm text-muted-foreground text-sm">
+                {description}
+            </p>
+            {action != null && action}
+        </div>
+    );
+};
+
+EmptyState.displayName = EMPTY_STATE_NAME;

--- a/src/main/resources/assets/js/components/ui/input.tsx
+++ b/src/main/resources/assets/js/components/ui/input.tsx
@@ -1,0 +1,26 @@
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+const INPUT_NAME = 'Input';
+
+export const Input = ({
+    ref,
+    className,
+    type,
+    ...props
+}: ComponentProps<'input'>): ReactElement => {
+    return (
+        <input
+            ref={ref}
+            type={type}
+            data-component={INPUT_NAME}
+            className={cn(
+                'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:font-medium file:text-foreground file:text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+Input.displayName = INPUT_NAME;

--- a/src/main/resources/assets/js/components/ui/label.tsx
+++ b/src/main/resources/assets/js/components/ui/label.tsx
@@ -1,0 +1,25 @@
+import * as LabelPrimitive from '@radix-ui/react-label';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+const LABEL_NAME = 'Label';
+
+export const Label = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof LabelPrimitive.Root>): ReactElement => {
+    return (
+        <LabelPrimitive.Root
+            ref={ref}
+            data-component={LABEL_NAME}
+            className={cn(
+                'font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+Label.displayName = LABEL_NAME;

--- a/src/main/resources/assets/js/components/ui/progress-dialog.tsx
+++ b/src/main/resources/assets/js/components/ui/progress-dialog.tsx
@@ -1,0 +1,51 @@
+import type { ReactElement } from 'react';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from './dialog';
+import { Progress } from './progress';
+
+export type ProgressDialogProps = {
+    title: string;
+    description?: string;
+    progress: number;
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+};
+
+const PROGRESS_DIALOG_NAME = 'ProgressDialog';
+
+export const ProgressDialog = ({
+    title,
+    description,
+    progress,
+    open,
+    onOpenChange,
+}: ProgressDialogProps): ReactElement => {
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent
+                data-component={PROGRESS_DIALOG_NAME}
+                onPointerDownOutside={(e) => e.preventDefault()}
+                onEscapeKeyDown={(e) => e.preventDefault()}
+                className="[&>button:last-child]:hidden"
+            >
+                <DialogHeader>
+                    <DialogTitle>{title}</DialogTitle>
+                    {description != null && (
+                        <DialogDescription>{description}</DialogDescription>
+                    )}
+                </DialogHeader>
+                <Progress value={progress} className="w-full" />
+                <p className="text-center text-muted-foreground text-sm">
+                    {Math.round(progress)}%
+                </p>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+ProgressDialog.displayName = PROGRESS_DIALOG_NAME;

--- a/src/main/resources/assets/js/components/ui/progress.tsx
+++ b/src/main/resources/assets/js/components/ui/progress.tsx
@@ -1,0 +1,31 @@
+import * as ProgressPrimitive from '@radix-ui/react-progress';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+const PROGRESS_NAME = 'Progress';
+
+export const Progress = ({
+    ref,
+    className,
+    value,
+    ...props
+}: ComponentProps<typeof ProgressPrimitive.Root>): ReactElement => {
+    return (
+        <ProgressPrimitive.Root
+            ref={ref}
+            data-component={PROGRESS_NAME}
+            className={cn(
+                'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
+                className,
+            )}
+            {...props}
+        >
+            <ProgressPrimitive.Indicator
+                className="h-full w-full flex-1 bg-primary transition-all"
+                style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
+            />
+        </ProgressPrimitive.Root>
+    );
+};
+
+Progress.displayName = PROGRESS_NAME;

--- a/src/main/resources/assets/js/components/ui/scroll-area.tsx
+++ b/src/main/resources/assets/js/components/ui/scroll-area.tsx
@@ -1,0 +1,66 @@
+import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+//
+// * ScrollBar
+//
+
+const SCROLL_BAR_NAME = 'ScrollBar';
+
+export const ScrollBar = ({
+    ref,
+    className,
+    orientation = 'vertical',
+    ...props
+}: ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>): ReactElement => {
+    return (
+        <ScrollAreaPrimitive.ScrollAreaScrollbar
+            ref={ref}
+            orientation={orientation}
+            className={cn(
+                'flex touch-none select-none transition-colors',
+                orientation === 'vertical' &&
+                    'h-full w-2.5 border-l border-l-transparent p-[1px]',
+                orientation === 'horizontal' &&
+                    'h-2.5 flex-col border-t border-t-transparent p-[1px]',
+                className,
+            )}
+            {...props}
+        >
+            <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+        </ScrollAreaPrimitive.ScrollAreaScrollbar>
+    );
+};
+
+ScrollBar.displayName = SCROLL_BAR_NAME;
+
+//
+// * ScrollArea
+//
+
+const SCROLL_AREA_NAME = 'ScrollArea';
+
+export const ScrollArea = ({
+    ref,
+    className,
+    children,
+    ...props
+}: ComponentProps<typeof ScrollAreaPrimitive.Root>): ReactElement => {
+    return (
+        <ScrollAreaPrimitive.Root
+            ref={ref}
+            data-component={SCROLL_AREA_NAME}
+            className={cn('relative overflow-hidden', className)}
+            {...props}
+        >
+            <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+                {children}
+            </ScrollAreaPrimitive.Viewport>
+            <ScrollBar />
+            <ScrollAreaPrimitive.Corner />
+        </ScrollAreaPrimitive.Root>
+    );
+};
+
+ScrollArea.displayName = SCROLL_AREA_NAME;

--- a/src/main/resources/assets/js/components/ui/select.tsx
+++ b/src/main/resources/assets/js/components/ui/select.tsx
@@ -1,0 +1,229 @@
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { Check, ChevronDown, ChevronUp } from 'lucide-react';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+//
+// * Select
+//
+
+export const Select = SelectPrimitive.Root;
+
+//
+// * SelectGroup
+//
+
+export const SelectGroup = SelectPrimitive.Group;
+
+//
+// * SelectValue
+//
+
+export const SelectValue = SelectPrimitive.Value;
+
+//
+// * SelectTrigger
+//
+
+const SELECT_TRIGGER_NAME = 'SelectTrigger';
+
+export const SelectTrigger = ({
+    ref,
+    className,
+    children,
+    ...props
+}: ComponentProps<typeof SelectPrimitive.Trigger>): ReactElement => {
+    return (
+        <SelectPrimitive.Trigger
+            ref={ref}
+            data-component={SELECT_TRIGGER_NAME}
+            className={cn(
+                'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+                className,
+            )}
+            {...props}
+        >
+            {children}
+            <SelectPrimitive.Icon asChild>
+                <ChevronDown className="size-4 opacity-50" />
+            </SelectPrimitive.Icon>
+        </SelectPrimitive.Trigger>
+    );
+};
+
+SelectTrigger.displayName = SELECT_TRIGGER_NAME;
+
+//
+// * SelectScrollUpButton
+//
+
+const SELECT_SCROLL_UP_NAME = 'SelectScrollUpButton';
+
+const SelectScrollUpButton = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof SelectPrimitive.ScrollUpButton>): ReactElement => {
+    return (
+        <SelectPrimitive.ScrollUpButton
+            ref={ref}
+            className={cn(
+                'flex cursor-default items-center justify-center py-1',
+                className,
+            )}
+            {...props}
+        >
+            <ChevronUp className="size-4" />
+        </SelectPrimitive.ScrollUpButton>
+    );
+};
+
+SelectScrollUpButton.displayName = SELECT_SCROLL_UP_NAME;
+
+//
+// * SelectScrollDownButton
+//
+
+const SELECT_SCROLL_DOWN_NAME = 'SelectScrollDownButton';
+
+const SelectScrollDownButton = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof SelectPrimitive.ScrollDownButton>): ReactElement => {
+    return (
+        <SelectPrimitive.ScrollDownButton
+            ref={ref}
+            className={cn(
+                'flex cursor-default items-center justify-center py-1',
+                className,
+            )}
+            {...props}
+        >
+            <ChevronDown className="size-4" />
+        </SelectPrimitive.ScrollDownButton>
+    );
+};
+
+SelectScrollDownButton.displayName = SELECT_SCROLL_DOWN_NAME;
+
+//
+// * SelectContent
+//
+
+const SELECT_CONTENT_NAME = 'SelectContent';
+
+export const SelectContent = ({
+    ref,
+    className,
+    children,
+    position = 'popper',
+    ...props
+}: ComponentProps<typeof SelectPrimitive.Content>): ReactElement => {
+    return (
+        <SelectPrimitive.Portal>
+            <SelectPrimitive.Content
+                ref={ref}
+                className={cn(
+                    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-card text-card-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in',
+                    position === 'popper' &&
+                        'data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1',
+                    className,
+                )}
+                position={position}
+                {...props}
+            >
+                <SelectScrollUpButton />
+                <SelectPrimitive.Viewport
+                    className={cn(
+                        'p-1',
+                        position === 'popper' &&
+                            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
+                    )}
+                >
+                    {children}
+                </SelectPrimitive.Viewport>
+                <SelectScrollDownButton />
+            </SelectPrimitive.Content>
+        </SelectPrimitive.Portal>
+    );
+};
+
+SelectContent.displayName = SELECT_CONTENT_NAME;
+
+//
+// * SelectLabel
+//
+
+const SELECT_LABEL_NAME = 'SelectLabel';
+
+export const SelectLabel = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof SelectPrimitive.Label>): ReactElement => {
+    return (
+        <SelectPrimitive.Label
+            ref={ref}
+            className={cn('py-1.5 pr-2 pl-8 font-semibold text-sm', className)}
+            {...props}
+        />
+    );
+};
+
+SelectLabel.displayName = SELECT_LABEL_NAME;
+
+//
+// * SelectItem
+//
+
+const SELECT_ITEM_NAME = 'SelectItem';
+
+export const SelectItem = ({
+    ref,
+    className,
+    children,
+    ...props
+}: ComponentProps<typeof SelectPrimitive.Item>): ReactElement => {
+    return (
+        <SelectPrimitive.Item
+            ref={ref}
+            className={cn(
+                'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+                className,
+            )}
+            {...props}
+        >
+            <span className="absolute left-2 flex size-3.5 items-center justify-center">
+                <SelectPrimitive.ItemIndicator>
+                    <Check className="size-4" />
+                </SelectPrimitive.ItemIndicator>
+            </span>
+            <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+        </SelectPrimitive.Item>
+    );
+};
+
+SelectItem.displayName = SELECT_ITEM_NAME;
+
+//
+// * SelectSeparator
+//
+
+const SELECT_SEPARATOR_NAME = 'SelectSeparator';
+
+export const SelectSeparator = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof SelectPrimitive.Separator>): ReactElement => {
+    return (
+        <SelectPrimitive.Separator
+            ref={ref}
+            className={cn('-mx-1 my-1 h-px bg-muted', className)}
+            {...props}
+        />
+    );
+};
+
+SelectSeparator.displayName = SELECT_SEPARATOR_NAME;

--- a/src/main/resources/assets/js/components/ui/separator.tsx
+++ b/src/main/resources/assets/js/components/ui/separator.tsx
@@ -1,0 +1,32 @@
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+const SEPARATOR_NAME = 'Separator';
+
+export const Separator = ({
+    ref,
+    className,
+    orientation = 'horizontal',
+    decorative = true,
+    ...props
+}: ComponentProps<typeof SeparatorPrimitive.Root>): ReactElement => {
+    return (
+        <SeparatorPrimitive.Root
+            ref={ref}
+            data-component={SEPARATOR_NAME}
+            decorative={decorative}
+            orientation={orientation}
+            className={cn(
+                'shrink-0 bg-border',
+                orientation === 'horizontal'
+                    ? 'h-[1px] w-full'
+                    : 'h-full w-[1px]',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+Separator.displayName = SEPARATOR_NAME;

--- a/src/main/resources/assets/js/components/ui/sheet.tsx
+++ b/src/main/resources/assets/js/components/ui/sheet.tsx
@@ -1,0 +1,196 @@
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+//
+// * Sheet
+//
+
+export const Sheet = SheetPrimitive.Root;
+
+//
+// * SheetTrigger
+//
+
+export const SheetTrigger = SheetPrimitive.Trigger;
+
+//
+// * SheetClose
+//
+
+export const SheetClose = SheetPrimitive.Close;
+
+//
+// * SheetPortal
+//
+
+export const SheetPortal = SheetPrimitive.Portal;
+
+//
+// * SheetOverlay
+//
+
+const SHEET_OVERLAY_NAME = 'SheetOverlay';
+
+export const SheetOverlay = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof SheetPrimitive.Overlay>): ReactElement => {
+    return (
+        <SheetPrimitive.Overlay
+            ref={ref}
+            className={cn(
+                'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 data-[state=closed]:animate-out data-[state=open]:animate-in',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+SheetOverlay.displayName = SHEET_OVERLAY_NAME;
+
+//
+// * SheetContent
+//
+
+const sheetVariants = cva(
+    'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:duration-300 data-[state=open]:duration-500',
+    {
+        variants: {
+            side: {
+                top: 'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 border-b',
+                bottom: 'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 border-t',
+                left: 'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm',
+                right: 'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
+            },
+        },
+        defaultVariants: {
+            side: 'right',
+        },
+    },
+);
+
+const SHEET_CONTENT_NAME = 'SheetContent';
+
+export const SheetContent = ({
+    ref,
+    side = 'right',
+    className,
+    children,
+    ...props
+}: ComponentProps<typeof SheetPrimitive.Content> &
+    VariantProps<typeof sheetVariants>): ReactElement => {
+    return (
+        <SheetPortal>
+            <SheetOverlay />
+            <SheetPrimitive.Content
+                ref={ref}
+                data-component={SHEET_CONTENT_NAME}
+                className={cn(sheetVariants({ side }), className)}
+                {...props}
+            >
+                {children}
+                <SheetPrimitive.Close className="absolute top-4 right-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+                    <X className="size-4" />
+                    <span className="sr-only">Close</span>
+                </SheetPrimitive.Close>
+            </SheetPrimitive.Content>
+        </SheetPortal>
+    );
+};
+
+SheetContent.displayName = SHEET_CONTENT_NAME;
+
+//
+// * SheetHeader
+//
+
+const SHEET_HEADER_NAME = 'SheetHeader';
+
+export const SheetHeader = ({
+    className,
+    ...props
+}: ComponentProps<'div'>): ReactElement => {
+    return (
+        <div
+            className={cn(
+                'flex flex-col space-y-2 text-center sm:text-left',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+SheetHeader.displayName = SHEET_HEADER_NAME;
+
+//
+// * SheetFooter
+//
+
+const SHEET_FOOTER_NAME = 'SheetFooter';
+
+export const SheetFooter = ({
+    className,
+    ...props
+}: ComponentProps<'div'>): ReactElement => {
+    return (
+        <div
+            className={cn(
+                'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+SheetFooter.displayName = SHEET_FOOTER_NAME;
+
+//
+// * SheetTitle
+//
+
+const SHEET_TITLE_NAME = 'SheetTitle';
+
+export const SheetTitle = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof SheetPrimitive.Title>): ReactElement => {
+    return (
+        <SheetPrimitive.Title
+            ref={ref}
+            className={cn('font-semibold text-foreground text-lg', className)}
+            {...props}
+        />
+    );
+};
+
+SheetTitle.displayName = SHEET_TITLE_NAME;
+
+//
+// * SheetDescription
+//
+
+const SHEET_DESCRIPTION_NAME = 'SheetDescription';
+
+export const SheetDescription = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof SheetPrimitive.Description>): ReactElement => {
+    return (
+        <SheetPrimitive.Description
+            ref={ref}
+            className={cn('text-muted-foreground text-sm', className)}
+            {...props}
+        />
+    );
+};
+
+SheetDescription.displayName = SHEET_DESCRIPTION_NAME;

--- a/src/main/resources/assets/js/components/ui/skeleton.tsx
+++ b/src/main/resources/assets/js/components/ui/skeleton.tsx
@@ -1,0 +1,19 @@
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+const SKELETON_NAME = 'Skeleton';
+
+export const Skeleton = ({
+    className,
+    ...props
+}: ComponentProps<'div'>): ReactElement => {
+    return (
+        <div
+            data-component={SKELETON_NAME}
+            className={cn('animate-pulse rounded-md bg-muted', className)}
+            {...props}
+        />
+    );
+};
+
+Skeleton.displayName = SKELETON_NAME;

--- a/src/main/resources/assets/js/components/ui/sonner.tsx
+++ b/src/main/resources/assets/js/components/ui/sonner.tsx
@@ -1,0 +1,31 @@
+import type { ReactElement } from 'react';
+import { Toaster as Sonner, toast } from 'sonner';
+import { useTheme } from '../theme-provider';
+
+const TOASTER_NAME = 'Toaster';
+
+export const Toaster = (): ReactElement => {
+    const { theme } = useTheme();
+
+    return (
+        <Sonner
+            data-component={TOASTER_NAME}
+            theme={theme === 'system' ? undefined : theme}
+            className="toaster group"
+            toastOptions={{
+                classNames: {
+                    toast: 'group toast group-[.toaster]:border-border group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:shadow-lg',
+                    description: 'group-[.toast]:text-muted-foreground',
+                    actionButton:
+                        'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+                    cancelButton:
+                        'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+                },
+            }}
+        />
+    );
+};
+
+Toaster.displayName = TOASTER_NAME;
+
+export { toast };

--- a/src/main/resources/assets/js/components/ui/table.tsx
+++ b/src/main/resources/assets/js/components/ui/table.tsx
@@ -1,0 +1,193 @@
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+//
+// * Table
+//
+
+const TABLE_NAME = 'Table';
+
+export const Table = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'table'>): ReactElement => {
+    return (
+        <div className="relative w-full overflow-auto">
+            <table
+                ref={ref}
+                data-component={TABLE_NAME}
+                className={cn('w-full caption-bottom text-sm', className)}
+                {...props}
+            />
+        </div>
+    );
+};
+
+Table.displayName = TABLE_NAME;
+
+//
+// * TableHeader
+//
+
+const TABLE_HEADER_NAME = 'TableHeader';
+
+export const TableHeader = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'thead'>): ReactElement => {
+    return (
+        <thead
+            ref={ref}
+            className={cn('[&_tr]:border-b', className)}
+            {...props}
+        />
+    );
+};
+
+TableHeader.displayName = TABLE_HEADER_NAME;
+
+//
+// * TableBody
+//
+
+const TABLE_BODY_NAME = 'TableBody';
+
+export const TableBody = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'tbody'>): ReactElement => {
+    return (
+        <tbody
+            ref={ref}
+            className={cn('[&_tr:last-child]:border-0', className)}
+            {...props}
+        />
+    );
+};
+
+TableBody.displayName = TABLE_BODY_NAME;
+
+//
+// * TableFooter
+//
+
+const TABLE_FOOTER_NAME = 'TableFooter';
+
+export const TableFooter = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'tfoot'>): ReactElement => {
+    return (
+        <tfoot
+            ref={ref}
+            className={cn(
+                'border-t bg-muted/50 font-medium [&>tr]:last:border-b-0',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+TableFooter.displayName = TABLE_FOOTER_NAME;
+
+//
+// * TableRow
+//
+
+const TABLE_ROW_NAME = 'TableRow';
+
+export const TableRow = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'tr'>): ReactElement => {
+    return (
+        <tr
+            ref={ref}
+            className={cn(
+                'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+TableRow.displayName = TABLE_ROW_NAME;
+
+//
+// * TableHead
+//
+
+const TABLE_HEAD_NAME = 'TableHead';
+
+export const TableHead = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'th'>): ReactElement => {
+    return (
+        <th
+            ref={ref}
+            className={cn(
+                'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+TableHead.displayName = TABLE_HEAD_NAME;
+
+//
+// * TableCell
+//
+
+const TABLE_CELL_NAME = 'TableCell';
+
+export const TableCell = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'td'>): ReactElement => {
+    return (
+        <td
+            ref={ref}
+            className={cn(
+                'p-4 align-middle [&:has([role=checkbox])]:pr-0',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+TableCell.displayName = TABLE_CELL_NAME;
+
+//
+// * TableCaption
+//
+
+const TABLE_CAPTION_NAME = 'TableCaption';
+
+export const TableCaption = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'caption'>): ReactElement => {
+    return (
+        <caption
+            ref={ref}
+            className={cn('mt-4 text-muted-foreground text-sm', className)}
+            {...props}
+        />
+    );
+};
+
+TableCaption.displayName = TABLE_CAPTION_NAME;

--- a/src/main/resources/assets/js/components/ui/tabs.tsx
+++ b/src/main/resources/assets/js/components/ui/tabs.tsx
@@ -1,0 +1,85 @@
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+//
+// * Tabs
+//
+
+export const Tabs = TabsPrimitive.Root;
+
+//
+// * TabsList
+//
+
+const TABS_LIST_NAME = 'TabsList';
+
+export const TabsList = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof TabsPrimitive.List>): ReactElement => {
+    return (
+        <TabsPrimitive.List
+            ref={ref}
+            data-component={TABS_LIST_NAME}
+            className={cn(
+                'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+TabsList.displayName = TABS_LIST_NAME;
+
+//
+// * TabsTrigger
+//
+
+const TABS_TRIGGER_NAME = 'TabsTrigger';
+
+export const TabsTrigger = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof TabsPrimitive.Trigger>): ReactElement => {
+    return (
+        <TabsPrimitive.Trigger
+            ref={ref}
+            className={cn(
+                'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 font-medium text-sm ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+TabsTrigger.displayName = TABS_TRIGGER_NAME;
+
+//
+// * TabsContent
+//
+
+const TABS_CONTENT_NAME = 'TabsContent';
+
+export const TabsContent = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<typeof TabsPrimitive.Content>): ReactElement => {
+    return (
+        <TabsPrimitive.Content
+            ref={ref}
+            className={cn(
+                'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+TabsContent.displayName = TABS_CONTENT_NAME;

--- a/src/main/resources/assets/js/components/ui/textarea.tsx
+++ b/src/main/resources/assets/js/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+const TEXTAREA_NAME = 'Textarea';
+
+export const Textarea = ({
+    ref,
+    className,
+    ...props
+}: ComponentProps<'textarea'>): ReactElement => {
+    return (
+        <textarea
+            ref={ref}
+            data-component={TEXTAREA_NAME}
+            className={cn(
+                'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+                className,
+            )}
+            {...props}
+        />
+    );
+};
+
+Textarea.displayName = TEXTAREA_NAME;

--- a/src/main/resources/assets/js/components/ui/tooltip.tsx
+++ b/src/main/resources/assets/js/components/ui/tooltip.tsx
@@ -1,0 +1,51 @@
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import type { ComponentProps, ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+
+//
+// * TooltipProvider
+//
+
+export const TooltipProvider = TooltipPrimitive.Provider;
+
+//
+// * Tooltip
+//
+
+export const Tooltip = TooltipPrimitive.Root;
+
+//
+// * TooltipTrigger
+//
+
+export const TooltipTrigger = TooltipPrimitive.Trigger;
+
+//
+// * TooltipContent
+//
+
+const TOOLTIP_CONTENT_NAME = 'TooltipContent';
+
+export const TooltipContent = ({
+    ref,
+    className,
+    sideOffset = 4,
+    ...props
+}: ComponentProps<typeof TooltipPrimitive.Content>): ReactElement => {
+    return (
+        <TooltipPrimitive.Portal>
+            <TooltipPrimitive.Content
+                ref={ref}
+                data-component={TOOLTIP_CONTENT_NAME}
+                sideOffset={sideOffset}
+                className={cn(
+                    'fade-in-0 zoom-in-95 data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 animate-in overflow-hidden rounded-md border bg-card px-3 py-1.5 text-card-foreground text-sm shadow-md data-[state=closed]:animate-out',
+                    className,
+                )}
+                {...props}
+            />
+        </TooltipPrimitive.Portal>
+    );
+};
+
+TooltipContent.displayName = TOOLTIP_CONTENT_NAME;


### PR DESCRIPTION
Added 22 UI components in `components/ui/`:
- Layout: Card, Separator, ScrollArea, Skeleton
- Forms: Button (CVA variants), Input, Label, Textarea, Select, Checkbox
- Feedback: Badge (CVA variants), Tooltip, Progress
- Overlays: Dialog, AlertDialog, DropdownMenu, Sheet (CVA side variants)
- Data: Table primitives, Tabs
- Toast: Sonner integration with `Toaster` and `toast()`
- Specialized: ConfirmDialog, ProgressDialog, EmptyState
Wired `TooltipProvider` and `Toaster` into `app.tsx`.
Installed `@radix-ui/react-progress` dependency.

https://claude.ai/code/session_01JpPDW4M6yvXZq1iMj4eVrJ