### PR TITLE
feat: implement branch list with create and delete #7

### DIFF
--- a/src/main/resources/admin/tools/main/main.ts
+++ b/src/main/resources/admin/tools/main/main.ts
@@ -11,6 +11,7 @@ type DataKitConfig = {
     apiUris: {
         system: string;
         repositories: string;
+        branches: string;
     };
     launcherUri: string;
     user: {
@@ -29,6 +30,7 @@ function buildConfig(): DataKitConfig {
         apiUris: {
             system: apiUrl({ api: 'system', type: 'server' }),
             repositories: apiUrl({ api: 'repositories', type: 'server' }),
+            branches: apiUrl({ api: 'branches', type: 'server' }),
         },
         launcherUri: extensionUrl({
             application: 'com.enonic.xp.app.main',

--- a/src/main/resources/admin/tools/main/main.yml
+++ b/src/main/resources/admin/tools/main/main.yml
@@ -12,3 +12,4 @@ apis:
   - "admin:status"
   - "system"
   - "repositories"
+  - "branches"

--- a/src/main/resources/apis/branches/branches.ts
+++ b/src/main/resources/apis/branches/branches.ts
@@ -1,0 +1,98 @@
+import type { Request, Response } from '@enonic-types/core';
+import { createBranch, deleteBranch, get as getRepo } from '/lib/xp/repo';
+import { errorResponse, getParam, jsonResponse, requireAdmin } from '../../lib/api';
+
+type BranchDto = {
+    id: string;
+};
+
+const PROTECTED_BRANCHES = ['master'];
+
+const BRANCH_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,98}[a-z0-9]$/;
+
+export function get(req: Request): Response {
+    const forbidden = requireAdmin();
+    if (forbidden != null) return forbidden;
+
+    const repoId = getParam(req, 'repoId');
+    if (repoId == null) {
+        return errorResponse(400, 'Repository ID is required', 'VALIDATION_ERROR');
+    }
+
+    try {
+        const repo = getRepo(repoId);
+        if (repo == null) {
+            return errorResponse(404, `Repository '${repoId}' not found`, 'NOT_FOUND');
+        }
+
+        const branches: BranchDto[] = [];
+        for (let i = 0; i < repo.branches.length; i++) {
+            branches.push({ id: repo.branches[i] });
+        }
+
+        return jsonResponse(branches);
+    } catch (_e) {
+        return errorResponse(404, `Repository '${repoId}' not found`, 'NOT_FOUND');
+    }
+}
+
+export function post(req: Request): Response {
+    const forbidden = requireAdmin();
+    if (forbidden != null) return forbidden;
+
+    const body = req.body != null ? JSON.parse(req.body as string) : {};
+    const repoId = body.repoId as string | undefined;
+    const branchId = body.branchId as string | undefined;
+
+    if (repoId == null || typeof repoId !== 'string') {
+        return errorResponse(400, 'Repository ID is required', 'VALIDATION_ERROR');
+    }
+
+    if (branchId == null || typeof branchId !== 'string') {
+        return errorResponse(400, 'Branch ID is required', 'VALIDATION_ERROR');
+    }
+
+    if (!BRANCH_ID_PATTERN.test(branchId)) {
+        return errorResponse(
+            400,
+            'Branch ID must be 2-100 characters: lowercase letters, digits, dots, hyphens',
+            'VALIDATION_ERROR',
+        );
+    }
+
+    try {
+        const result = createBranch({ repoId, branchId });
+        return jsonResponse({ id: result.id } satisfies BranchDto, 201);
+    } catch (_e) {
+        return errorResponse(409, `Branch '${branchId}' already exists or repository not found`, 'CONFLICT');
+    }
+}
+
+function delete_(req: Request): Response {
+    const forbidden = requireAdmin();
+    if (forbidden != null) return forbidden;
+
+    const repoId = getParam(req, 'repoId');
+    const branchId = getParam(req, 'branchId');
+
+    if (repoId == null) {
+        return errorResponse(400, 'Repository ID is required', 'VALIDATION_ERROR');
+    }
+
+    if (branchId == null) {
+        return errorResponse(400, 'Branch ID is required', 'VALIDATION_ERROR');
+    }
+
+    if (PROTECTED_BRANCHES.indexOf(branchId) !== -1) {
+        return errorResponse(403, `Branch '${branchId}' is protected and cannot be deleted`, 'PROTECTED_BRANCH');
+    }
+
+    try {
+        deleteBranch({ repoId, branchId });
+        return jsonResponse({ id: branchId, deleted: true });
+    } catch (_e) {
+        return errorResponse(404, `Branch '${branchId}' not found`, 'NOT_FOUND');
+    }
+}
+
+export { delete_ as delete };

--- a/src/main/resources/apis/branches/branches.yml
+++ b/src/main/resources/apis/branches/branches.yml
@@ -1,0 +1,2 @@
+allow:
+  - "role:system.admin"

--- a/src/main/resources/assets/js/lib/api/branches.ts
+++ b/src/main/resources/assets/js/lib/api/branches.ts
@@ -1,0 +1,59 @@
+import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getConfig } from '../config';
+import { apiFetch } from './client';
+
+export type Branch = {
+    id: string;
+};
+
+export function fetchBranches(repoId: string): Promise<Branch[]> {
+    const { apiUris } = getConfig();
+    return apiFetch<Branch[]>(apiUris.branches, {
+        params: { repoId },
+    });
+}
+
+export function createBranch(repoId: string, branchId: string): Promise<Branch> {
+    const { apiUris } = getConfig();
+    return apiFetch<Branch>(apiUris.branches, {
+        method: 'POST',
+        body: { repoId, branchId },
+    });
+}
+
+export function deleteBranch(repoId: string, branchId: string): Promise<{ id: string; deleted: boolean }> {
+    const { apiUris } = getConfig();
+    return apiFetch<{ id: string; deleted: boolean }>(apiUris.branches, {
+        method: 'DELETE',
+        params: { repoId, branchId },
+    });
+}
+
+export function branchesQueryOptions(repoId: string) {
+    return queryOptions({
+        queryKey: ['branches', repoId],
+        queryFn: () => fetchBranches(repoId),
+    });
+}
+
+export function useCreateBranch() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ repoId, branchId }: { repoId: string; branchId: string }) =>
+            createBranch(repoId, branchId),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['branches'] });
+        },
+    });
+}
+
+export function useDeleteBranch() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ repoId, branchId }: { repoId: string; branchId: string }) =>
+            deleteBranch(repoId, branchId),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['branches'] });
+        },
+    });
+}

--- a/src/main/resources/assets/js/lib/config.ts
+++ b/src/main/resources/assets/js/lib/config.ts
@@ -10,6 +10,7 @@ export type DataKitConfig = {
     apiUris: {
         system: string;
         repositories: string;
+        branches: string;
     };
     launcherUri: string;
     user: UserConfig | null;

--- a/src/main/resources/assets/js/routes/repositories.$repoId.tsx
+++ b/src/main/resources/assets/js/routes/repositories.$repoId.tsx
@@ -1,23 +1,332 @@
-import { createFileRoute } from '@tanstack/react-router';
-import type { ReactElement } from 'react';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import {
+    createColumnHelper,
+    flexRender,
+    getCoreRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { ChevronRight, GitBranch, Plus, Trash2 } from 'lucide-react';
+import { type ReactElement, useState } from 'react';
+import { z } from 'zod';
+import { Button } from '../components/ui/button';
+import { ConfirmDialog } from '../components/ui/confirm-dialog';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '../components/ui/dialog';
+import { EmptyState } from '../components/ui/empty-state';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
+import { toast } from '../components/ui/sonner';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '../components/ui/table';
+import {
+    type Branch,
+    branchesQueryOptions,
+    useCreateBranch,
+    useDeleteBranch,
+} from '../lib/api/branches';
 
-const REPOSITORY_DETAIL_PAGE_NAME = 'RepositoryDetailPage';
+const BRANCH_LIST_PAGE_NAME = 'BranchListPage';
 
-const RepositoryDetailPage = (): ReactElement => {
-    const { repoId } = Route.useParams();
+const PROTECTED_BRANCHES = ['master'];
+
+const branchIdSchema = z
+    .string()
+    .min(2, 'Must be at least 2 characters')
+    .max(100, 'Must be at most 100 characters')
+    .regex(
+        /^[a-z0-9][a-z0-9._-]*[a-z0-9]$/,
+        'Must contain only lowercase letters, digits, dots, and hyphens',
+    );
+
+const columnHelper = createColumnHelper<Branch>();
+
+//
+// * DeleteAction
+//
+
+type DeleteActionProps = {
+    repoId: string;
+    branch: Branch;
+};
+
+const DeleteAction = ({ repoId, branch }: DeleteActionProps): ReactElement => {
+    const [open, setOpen] = useState(false);
+    const deleteMutation = useDeleteBranch();
+    const isProtected = PROTECTED_BRANCHES.includes(branch.id);
+
+    const handleConfirm = () => {
+        deleteMutation.mutate(
+            { repoId, branchId: branch.id },
+            {
+                onSuccess: () => {
+                    toast.success(`Branch '${branch.id}' deleted`);
+                    setOpen(false);
+                },
+                onError: () => {
+                    toast.error(`Failed to delete branch '${branch.id}'`);
+                },
+            },
+        );
+    };
+
+    if (isProtected) {
+        return (
+            <ConfirmDialog
+                title="Protected Branch"
+                description={`'${branch.id}' is a default branch and cannot be deleted.`}
+                confirmLabel="OK"
+                cancelLabel="Close"
+                variant="default"
+                onConfirm={() => setOpen(false)}
+                open={open}
+                onOpenChange={setOpen}
+            >
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    onClick={e => e.stopPropagation()}
+                >
+                    <Trash2 className="size-4 text-muted-foreground" />
+                </Button>
+            </ConfirmDialog>
+        );
+    }
 
     return (
-        <div data-component={REPOSITORY_DETAIL_PAGE_NAME} className="p-6">
-            <h2 className="font-semibold text-2xl">{repoId}</h2>
-            <p className="mt-2 text-muted-foreground">
-                Repository details and branches will be displayed here.
-            </p>
+        <ConfirmDialog
+            title="Delete Branch"
+            description={`Are you sure you want to delete '${branch.id}'? This action cannot be undone.`}
+            confirmLabel="Delete"
+            cancelLabel="Cancel"
+            variant="destructive"
+            onConfirm={handleConfirm}
+            open={open}
+            onOpenChange={setOpen}
+        >
+            <Button
+                variant="ghost"
+                size="icon"
+                className="size-8"
+                onClick={e => e.stopPropagation()}
+            >
+                <Trash2 className="size-4 text-muted-foreground" />
+            </Button>
+        </ConfirmDialog>
+    );
+};
+
+//
+// * CreateBranchDialog
+//
+
+type CreateBranchDialogProps = {
+    repoId: string;
+};
+
+const CreateBranchDialog = ({ repoId }: CreateBranchDialogProps): ReactElement => {
+    const [open, setOpen] = useState(false);
+    const [name, setName] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const createMutation = useCreateBranch();
+
+    const handleSubmit = () => {
+        const result = branchIdSchema.safeParse(name);
+        if (!result.success) {
+            setError(result.error.issues[0].message);
+            return;
+        }
+
+        createMutation.mutate(
+            { repoId, branchId: name },
+            {
+                onSuccess: () => {
+                    toast.success(`Branch '${name}' created`);
+                    setOpen(false);
+                    setName('');
+                    setError(null);
+                },
+                onError: () => {
+                    toast.error(`Failed to create branch '${name}'`);
+                },
+            },
+        );
+    };
+
+    const handleOpenChange = (nextOpen: boolean) => {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+            setName('');
+            setError(null);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogTrigger asChild>
+                <Button>
+                    <Plus className="size-4" />
+                    Create Branch
+                </Button>
+            </DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Create Branch</DialogTitle>
+                    <DialogDescription>
+                        Enter a name for the new branch. Use lowercase
+                        letters, digits, dots, and hyphens.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="grid gap-2 py-4">
+                    <Label htmlFor="branch-name">Branch Name</Label>
+                    <Input
+                        id="branch-name"
+                        value={name}
+                        onChange={e => {
+                            setName(e.target.value);
+                            setError(null);
+                        }}
+                        onKeyDown={e => {
+                            if (e.key === 'Enter') handleSubmit();
+                        }}
+                        placeholder="draft"
+                    />
+                    {error != null && (
+                        <p className="text-destructive text-sm">{error}</p>
+                    )}
+                </div>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button variant="outline">Cancel</Button>
+                    </DialogClose>
+                    <Button
+                        onClick={handleSubmit}
+                        disabled={createMutation.isPending}
+                    >
+                        Create
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+//
+// * BranchListPage
+//
+
+const BranchListPage = (): ReactElement => {
+    const { repoId } = Route.useParams();
+    const { data: branches } = useSuspenseQuery(
+        branchesQueryOptions(repoId),
+    );
+    const columns = [
+        columnHelper.accessor('id', {
+            header: 'Name',
+            cell: info => (
+                <span className="font-medium">{info.getValue()}</span>
+            ),
+        }),
+        columnHelper.display({
+            id: 'actions',
+            header: '',
+            cell: info => <DeleteAction repoId={repoId} branch={info.row.original} />,
+        }),
+    ];
+
+    const table = useReactTable({
+        data: branches,
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+    });
+
+    return (
+        <div data-component={BRANCH_LIST_PAGE_NAME} className="p-6">
+            <div className="mb-6 flex items-center justify-between">
+                <div>
+                    <div className="mb-1 flex items-center gap-1.5 text-muted-foreground text-sm">
+                        <Link
+                            to="/repositories"
+                            className="hover:text-foreground"
+                        >
+                            Repositories
+                        </Link>
+                        <ChevronRight className="size-3.5" />
+                        <span className="text-foreground">{repoId}</span>
+                    </div>
+                    <h2 className="font-semibold text-2xl">Branches</h2>
+                    <p className="mt-1 text-muted-foreground text-sm">
+                        Manage branches in <span className="font-medium">{repoId}</span>.
+                    </p>
+                </div>
+                <CreateBranchDialog repoId={repoId} />
+            </div>
+
+            {branches.length === 0 ? (
+                <EmptyState
+                    icon={GitBranch}
+                    title="No branches"
+                    description="No branches found. Create one to get started."
+                    action={<CreateBranchDialog repoId={repoId} />}
+                />
+            ) : (
+                <Table>
+                    <TableHeader>
+                        {table.getHeaderGroups().map(headerGroup => (
+                            <TableRow key={headerGroup.id}>
+                                {headerGroup.headers.map(header => (
+                                    <TableHead key={header.id}>
+                                        {header.isPlaceholder
+                                            ? null
+                                            : flexRender(
+                                                  header.column.columnDef
+                                                      .header,
+                                                  header.getContext(),
+                                              )}
+                                    </TableHead>
+                                ))}
+                            </TableRow>
+                        ))}
+                    </TableHeader>
+                    <TableBody>
+                        {table.getRowModel().rows.map(row => (
+                            <TableRow key={row.id}>
+                                {row.getVisibleCells().map(cell => (
+                                    <TableCell key={cell.id}>
+                                        {flexRender(
+                                            cell.column.columnDef.cell,
+                                            cell.getContext(),
+                                        )}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            )}
         </div>
     );
 };
 
-RepositoryDetailPage.displayName = REPOSITORY_DETAIL_PAGE_NAME;
+BranchListPage.displayName = BRANCH_LIST_PAGE_NAME;
 
 export const Route = createFileRoute('/repositories/$repoId')({
-    component: RepositoryDetailPage,
+    loader: ({ context: { queryClient }, params: { repoId } }) =>
+        queryClient.ensureQueryData(branchesQueryOptions(repoId)),
+    component: BranchListPage,
 });

--- a/src/test/apis/branches.test.ts
+++ b/src/test/apis/branches.test.ts
@@ -1,0 +1,223 @@
+import type { Request } from '@enonic-types/core';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('/lib/xp/auth', () => ({
+    hasRole: vi.fn(() => true),
+}));
+
+vi.mock('/lib/xp/repo', () => ({
+    get: vi.fn(),
+    createBranch: vi.fn(),
+    deleteBranch: vi.fn(),
+}));
+
+import { hasRole } from '/lib/xp/auth';
+import { createBranch, deleteBranch, get as getRepo } from '/lib/xp/repo';
+import {
+    delete as deleteHandler,
+    get,
+    post,
+} from '../../main/resources/apis/branches/branches';
+
+const mockedGetRepo = vi.mocked(getRepo);
+const mockedCreateBranch = vi.mocked(createBranch);
+const mockedDeleteBranch = vi.mocked(deleteBranch);
+const mockedHasRole = vi.mocked(hasRole);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockedHasRole.mockReturnValue(true);
+});
+
+function parseBody(response: { body?: string | object }) {
+    return JSON.parse(response.body as string);
+}
+
+describe('GET /branches', () => {
+    test('returns branch list for a repository', () => {
+        mockedGetRepo.mockReturnValue({
+            id: 'my-repo',
+            branches: ['master', 'draft'],
+            settings: {},
+            transient: false,
+        });
+
+        const response = get({
+            params: { repoId: 'my-repo' },
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(response.status).toBe(200);
+        expect(body.data).toEqual([
+            { id: 'master' },
+            { id: 'draft' },
+        ]);
+        expect(mockedGetRepo).toHaveBeenCalledWith('my-repo');
+    });
+
+    test('requires repoId parameter', () => {
+        const response = get({
+            params: {},
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 404 for non-existent repository', () => {
+        mockedGetRepo.mockImplementation(() => {
+            throw new Error('Repository not found');
+        });
+
+        const response = get({
+            params: { repoId: 'nonexistent' },
+        } as unknown as Request);
+        expect(response.status).toBe(404);
+        expect(parseBody(response).code).toBe('NOT_FOUND');
+    });
+
+    test('returns 403 for non-admin', () => {
+        mockedHasRole.mockReturnValue(false);
+        const response = get({
+            params: { repoId: 'my-repo' },
+        } as unknown as Request);
+        expect(response.status).toBe(403);
+    });
+});
+
+describe('POST /branches', () => {
+    test('creates a branch with valid input', () => {
+        mockedCreateBranch.mockReturnValue({ id: 'draft' });
+
+        const response = post({
+            body: JSON.stringify({ repoId: 'my-repo', branchId: 'draft' }),
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(response.status).toBe(201);
+        expect(body.data).toEqual({ id: 'draft' });
+        expect(mockedCreateBranch).toHaveBeenCalledWith({
+            repoId: 'my-repo',
+            branchId: 'draft',
+        });
+    });
+
+    test('rejects missing repoId', () => {
+        const response = post({
+            body: JSON.stringify({ branchId: 'draft' }),
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('rejects missing branchId', () => {
+        const response = post({
+            body: JSON.stringify({ repoId: 'my-repo' }),
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('rejects invalid branchId format', () => {
+        const response = post({
+            body: JSON.stringify({ repoId: 'my-repo', branchId: 'AB' }),
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('rejects single character branchId', () => {
+        const response = post({
+            body: JSON.stringify({ repoId: 'my-repo', branchId: 'a' }),
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+    });
+
+    test('accepts branchId with dots and hyphens', () => {
+        mockedCreateBranch.mockReturnValue({ id: 'feature.my-branch' });
+
+        const response = post({
+            body: JSON.stringify({ repoId: 'my-repo', branchId: 'feature.my-branch' }),
+        } as unknown as Request);
+        expect(response.status).toBe(201);
+    });
+
+    test('returns 409 for duplicate branch', () => {
+        mockedCreateBranch.mockImplementation(() => {
+            throw new Error('Branch already exists');
+        });
+
+        const response = post({
+            body: JSON.stringify({ repoId: 'my-repo', branchId: 'master' }),
+        } as unknown as Request);
+        expect(response.status).toBe(409);
+        expect(parseBody(response).code).toBe('CONFLICT');
+    });
+
+    test('returns 403 for non-admin', () => {
+        mockedHasRole.mockReturnValue(false);
+        const response = post({
+            body: JSON.stringify({ repoId: 'my-repo', branchId: 'draft' }),
+        } as unknown as Request);
+        expect(response.status).toBe(403);
+    });
+});
+
+describe('DELETE /branches', () => {
+    test('deletes a branch', () => {
+        mockedDeleteBranch.mockReturnValue({ id: 'draft' });
+
+        const response = deleteHandler({
+            params: { repoId: 'my-repo', branchId: 'draft' },
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(response.status).toBe(200);
+        expect(body.data).toEqual({ id: 'draft', deleted: true });
+        expect(mockedDeleteBranch).toHaveBeenCalledWith({
+            repoId: 'my-repo',
+            branchId: 'draft',
+        });
+    });
+
+    test('protects master branch', () => {
+        const response = deleteHandler({
+            params: { repoId: 'my-repo', branchId: 'master' },
+        } as unknown as Request);
+        expect(response.status).toBe(403);
+        expect(parseBody(response).code).toBe('PROTECTED_BRANCH');
+    });
+
+    test('requires repoId parameter', () => {
+        const response = deleteHandler({
+            params: { branchId: 'draft' },
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+    });
+
+    test('requires branchId parameter', () => {
+        const response = deleteHandler({
+            params: { repoId: 'my-repo' },
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+    });
+
+    test('returns 404 for non-existent branch', () => {
+        mockedDeleteBranch.mockImplementation(() => {
+            throw new Error('Branch not found');
+        });
+
+        const response = deleteHandler({
+            params: { repoId: 'my-repo', branchId: 'nonexistent' },
+        } as unknown as Request);
+        expect(response.status).toBe(404);
+        expect(parseBody(response).code).toBe('NOT_FOUND');
+    });
+
+    test('returns 403 for non-admin', () => {
+        mockedHasRole.mockReturnValue(false);
+        const response = deleteHandler({
+            params: { repoId: 'my-repo', branchId: 'draft' },
+        } as unknown as Request);
+        expect(response.status).toBe(403);
+    });
+});


### PR DESCRIPTION
Added `branches` API with GET/POST/DELETE handlers for branch management
scoped to a selected repository. Registered the API in the admin tool
descriptor and wired config plumbing through to the frontend.

Replaced the `$repoId` route placeholder with a full branch list page
featuring a TanStack Table, create/delete dialogs with Zod validation,
toast feedback, breadcrumb navigation back to repositories, and
protection against deleting the `master` branch.

Added 18 backend tests covering all handler methods, validation,
protected-branch guards, and error cases.

https://claude.ai/code/session_01GXy1qdoPMErx2e6PhHFEvi