### PR TITLE
feat: implement NoQL search with results table #12

### DIFF
--- a/src/main/resources/admin/tools/main/main.ts
+++ b/src/main/resources/admin/tools/main/main.ts
@@ -13,6 +13,7 @@ type DataKitConfig = {
         repositories: string;
         branches: string;
         nodes: string;
+        search: string;
     };
     launcherUri: string;
     user: {
@@ -33,6 +34,7 @@ function buildConfig(): DataKitConfig {
             repositories: apiUrl({ api: 'repositories', type: 'server' }),
             branches: apiUrl({ api: 'branches', type: 'server' }),
             nodes: apiUrl({ api: 'nodes', type: 'server' }),
+            search: apiUrl({ api: 'search', type: 'server' }),
         },
         launcherUri: extensionUrl({
             application: 'com.enonic.xp.app.main',

--- a/src/main/resources/admin/tools/main/main.yml
+++ b/src/main/resources/admin/tools/main/main.yml
@@ -14,3 +14,4 @@ apis:
   - "repositories"
   - "branches"
   - "nodes"
+  - "search"

--- a/src/main/resources/apis/search/search.ts
+++ b/src/main/resources/apis/search/search.ts
@@ -1,0 +1,200 @@
+import type { PrincipalKey, Request, Response } from '@enonic-types/core';
+import { connect, multiRepoConnect } from '/lib/xp/node';
+import { list } from '/lib/xp/repo';
+import { errorResponse, jsonResponse, requireAdmin } from '../../lib/api';
+
+type SearchHitDto = {
+    _id: string;
+    _score: number;
+    _repoId: string;
+    _branch: string;
+    _name?: string;
+    _path?: string;
+    _nodeType?: string;
+};
+
+type SearchResult = {
+    hits: SearchHitDto[];
+    total: number;
+    executionTimeMs: number;
+};
+
+type SearchBody = {
+    query: string;
+    repoId?: string;
+    branch?: string;
+    start?: number;
+    count?: number;
+    sort?: string;
+};
+
+const DEFAULT_COUNT = 25;
+
+function querySingleRepo(
+    repoId: string,
+    branch: string,
+    query: string,
+    start: number,
+    count: number,
+    sort: string,
+): SearchResult {
+    const startTime = Date.now();
+
+    const repo = connect({ repoId, branch });
+    const queryResult = repo.query({ start, count, query, sort });
+
+    const hits: SearchHitDto[] = [];
+
+    if (queryResult.count > 0) {
+        const ids: string[] = [];
+        for (let i = 0; i < queryResult.hits.length; i++) {
+            ids.push(queryResult.hits[i].id);
+        }
+
+        const rawNodes = repo.get(ids);
+        const nodesArray = rawNodes == null ? [] : Array.isArray(rawNodes) ? rawNodes : [rawNodes];
+
+        for (let i = 0; i < queryResult.hits.length; i++) {
+            const hit = queryResult.hits[i];
+            const node = nodesArray[i];
+            hits.push({
+                _id: hit.id,
+                _score: hit.score,
+                _repoId: repoId,
+                _branch: branch,
+                _name: node != null ? node._name : undefined,
+                _path: node != null ? node._path : undefined,
+                _nodeType: node != null ? node._nodeType : undefined,
+            });
+        }
+    }
+
+    return {
+        hits,
+        total: queryResult.total,
+        executionTimeMs: Date.now() - startTime,
+    };
+}
+
+function queryAllRepos(
+    query: string,
+    start: number,
+    count: number,
+    sort: string,
+): SearchResult {
+    const startTime = Date.now();
+
+    const repos = list();
+    const sources: Array<{ repoId: string; branch: string; principals: PrincipalKey[] }> = [];
+
+    for (let i = 0; i < repos.length; i++) {
+        const repo = repos[i];
+        for (let j = 0; j < repo.branches.length; j++) {
+            sources.push({
+                repoId: repo.id,
+                branch: repo.branches[j],
+                principals: ['role:system.admin'],
+            });
+        }
+    }
+
+    if (sources.length === 0) {
+        return { hits: [], total: 0, executionTimeMs: Date.now() - startTime };
+    }
+
+    const connection = multiRepoConnect({ sources });
+    const queryResult = connection.query({ start, count, query, sort });
+
+    const hits: SearchHitDto[] = [];
+
+    for (let i = 0; i < queryResult.hits.length; i++) {
+        const hit = queryResult.hits[i];
+        hits.push({
+            _id: hit.id,
+            _score: hit.score,
+            _repoId: hit.repoId,
+            _branch: hit.branch,
+        });
+    }
+
+    // Enrich hits with node metadata by grouping by repo+branch
+    const groups: Record<string, { repoId: string; branch: string; indices: number[]; ids: string[] }> = {};
+    for (let i = 0; i < hits.length; i++) {
+        const h = hits[i];
+        const groupKey = `${h._repoId}::${h._branch}`;
+        if (groups[groupKey] == null) {
+            groups[groupKey] = { repoId: h._repoId, branch: h._branch, indices: [], ids: [] };
+        }
+        groups[groupKey].indices.push(i);
+        groups[groupKey].ids.push(h._id);
+    }
+
+    const groupKeys = Object.keys(groups);
+    for (let i = 0; i < groupKeys.length; i++) {
+        const group = groups[groupKeys[i]];
+        try {
+            const conn = connect({ repoId: group.repoId, branch: group.branch });
+            const rawNodes = conn.get(group.ids);
+            const nodesArray = rawNodes == null ? [] : Array.isArray(rawNodes) ? rawNodes : [rawNodes];
+
+            for (let j = 0; j < group.indices.length; j++) {
+                const idx = group.indices[j];
+                const node = nodesArray[j];
+                if (node != null) {
+                    hits[idx]._name = node._name;
+                    hits[idx]._path = node._path;
+                    hits[idx]._nodeType = node._nodeType;
+                }
+            }
+        } catch (_e) {
+            // Skip enrichment for inaccessible repos
+        }
+    }
+
+    return {
+        hits,
+        total: queryResult.total,
+        executionTimeMs: Date.now() - startTime,
+    };
+}
+
+export function post(req: Request): Response {
+    const forbidden = requireAdmin();
+    if (forbidden != null) return forbidden;
+
+    let body: SearchBody;
+    try {
+        body = req.body != null ? JSON.parse(req.body as string) : {};
+    } catch (_e) {
+        return errorResponse(400, 'Invalid JSON body', 'VALIDATION_ERROR');
+    }
+
+    const query = body.query;
+    if (query == null || typeof query !== 'string' || query.trim() === '') {
+        return errorResponse(400, 'Query is required', 'VALIDATION_ERROR');
+    }
+
+    const start = typeof body.start === 'number' ? body.start : 0;
+    const count = typeof body.count === 'number' ? body.count : DEFAULT_COUNT;
+    const sort = typeof body.sort === 'string' && body.sort.trim() !== '' ? body.sort : '_score DESC';
+
+    try {
+        let result: SearchResult;
+
+        if (body.repoId != null && body.branch != null) {
+            result = querySingleRepo(body.repoId, body.branch, query, start, count, sort);
+        } else {
+            result = queryAllRepos(query, start, count, sort);
+        }
+
+        return jsonResponse(result);
+    } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+
+        if (message.indexOf('ParseException') !== -1 || message.indexOf('parse') !== -1) {
+            return errorResponse(400, `Invalid NoQL syntax: ${message}`, 'QUERY_ERROR');
+        }
+
+        return errorResponse(500, `Search failed: ${message}`, 'INTERNAL_ERROR');
+    }
+}

--- a/src/main/resources/apis/search/search.yml
+++ b/src/main/resources/apis/search/search.yml
@@ -1,0 +1,2 @@
+allow:
+  - "role:system.admin"

--- a/src/main/resources/assets/js/lib/api/search.ts
+++ b/src/main/resources/assets/js/lib/api/search.ts
@@ -1,0 +1,35 @@
+import { getConfig } from '../config';
+import { apiFetch } from './client';
+
+export type SearchHit = {
+    _id: string;
+    _score: number;
+    _repoId: string;
+    _branch: string;
+    _name?: string;
+    _path?: string;
+    _nodeType?: string;
+};
+
+export type SearchResponse = {
+    hits: SearchHit[];
+    total: number;
+    executionTimeMs: number;
+};
+
+export type SearchParams = {
+    query: string;
+    repoId?: string;
+    branch?: string;
+    start?: number;
+    count?: number;
+    sort?: string;
+};
+
+export function executeSearch(params: SearchParams): Promise<SearchResponse> {
+    const { apiUris } = getConfig();
+    return apiFetch<SearchResponse>(apiUris.search, {
+        method: 'POST',
+        body: params,
+    });
+}

--- a/src/main/resources/assets/js/lib/config.ts
+++ b/src/main/resources/assets/js/lib/config.ts
@@ -12,6 +12,7 @@ export type DataKitConfig = {
         repositories: string;
         branches: string;
         nodes: string;
+        search: string;
     };
     launcherUri: string;
     user: UserConfig | null;

--- a/src/main/resources/assets/js/routes/search.tsx
+++ b/src/main/resources/assets/js/routes/search.tsx
@@ -1,15 +1,379 @@
-import { createFileRoute } from '@tanstack/react-router';
-import type { ReactElement } from 'react';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import {
+    createColumnHelper,
+    flexRender,
+    getCoreRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { ChevronLeft, ChevronRight, Loader2, Search, X } from 'lucide-react';
+import { type ReactElement, useCallback, useMemo, useState } from 'react';
+import { Badge } from '../components/ui/badge';
+import { Button } from '../components/ui/button';
+import { EmptyState } from '../components/ui/empty-state';
+import { Label } from '../components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '../components/ui/select';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '../components/ui/table';
+import { Textarea } from '../components/ui/textarea';
+import { type Repository, repositoriesQueryOptions } from '../lib/api/repositories';
+import { executeSearch, type SearchHit, type SearchParams, type SearchResponse } from '../lib/api/search';
 
 const SEARCH_PAGE_NAME = 'SearchPage';
 
+const ALL_REPOS = '__all__';
+
+const DEFAULT_COUNT = 25;
+
+const columnHelper = createColumnHelper<SearchHit>();
+
+function getParentPath(path: string): string {
+    if (path === '/') return '/';
+    const segments = path.split('/').filter(Boolean);
+    segments.pop();
+    return segments.length === 0 ? '/' : `/${segments.join('/')}`;
+}
+
+//
+// * SearchPage
+//
+
 const SearchPage = (): ReactElement => {
+    const { data: repositories } = useSuspenseQuery(repositoriesQueryOptions());
+
+    const [query, setQuery] = useState('');
+    const [repoId, setRepoId] = useState(ALL_REPOS);
+    const [branch, setBranch] = useState('');
+    const [start, setStart] = useState(0);
+    const [result, setResult] = useState<SearchResponse | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const selectedRepo = useMemo(
+        () => repositories.find((r: Repository) => r.id === repoId),
+        [repositories, repoId],
+    );
+
+    const branches = useMemo(
+        () => (selectedRepo != null ? selectedRepo.branches : []),
+        [selectedRepo],
+    );
+
+    const searchMutation = useMutation({
+        mutationFn: executeSearch,
+        onSuccess: (data: SearchResponse) => {
+            setResult(data);
+            setError(null);
+        },
+        onError: (err: unknown) => {
+            setResult(null);
+            const apiErr = err as { message?: string; code?: string };
+            setError(apiErr.message ?? 'Search failed');
+        },
+    });
+
+    const doSearch = useCallback(
+        (searchStart: number) => {
+            if (query.trim() === '') return;
+
+            const params: SearchParams = {
+                query: query.trim(),
+                start: searchStart,
+                count: DEFAULT_COUNT,
+            };
+
+            if (repoId !== ALL_REPOS) {
+                params.repoId = repoId;
+                params.branch = branch || (branches.length > 0 ? branches[0] : 'master');
+            }
+
+            setStart(searchStart);
+            searchMutation.mutate(params);
+        },
+        [query, repoId, branch, branches, searchMutation],
+    );
+
+    const handleSubmit = () => {
+        doSearch(0);
+    };
+
+    const handleClear = () => {
+        setQuery('');
+        setResult(null);
+        setError(null);
+        setStart(0);
+    };
+
+    const handleRepoChange = (value: string) => {
+        setRepoId(value);
+        setBranch('');
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+            handleSubmit();
+        }
+    };
+
+    const columns = useMemo(
+        () => [
+            columnHelper.accessor('_score', {
+                header: 'Score',
+                cell: info => (
+                    <span className="font-mono text-muted-foreground text-sm">
+                        {info.getValue().toFixed(2)}
+                    </span>
+                ),
+            }),
+            columnHelper.accessor('_name', {
+                header: 'Name',
+                cell: info => (
+                    <span className="font-medium">
+                        {info.getValue() ?? '\u2014'}
+                    </span>
+                ),
+            }),
+            columnHelper.accessor('_path', {
+                header: 'Path',
+                cell: info => {
+                    const hit = info.row.original;
+                    const path = info.getValue();
+                    if (path == null) return <span className="text-muted-foreground">{'\u2014'}</span>;
+
+                    return (
+                        <Link
+                            to="/repositories/$repoId/$branch"
+                            params={{
+                                repoId: hit._repoId,
+                                branch: hit._branch,
+                            }}
+                            search={{ path: getParentPath(path), nodeId: hit._id }}
+                            className="text-primary underline-offset-4 hover:underline"
+                            onClick={e => e.stopPropagation()}
+                        >
+                            {path}
+                        </Link>
+                    );
+                },
+            }),
+            columnHelper.accessor('_repoId', {
+                header: 'Repository',
+                cell: info => (
+                    <Badge variant="secondary">{info.getValue()}</Badge>
+                ),
+            }),
+            columnHelper.accessor('_branch', {
+                header: 'Branch',
+                cell: info => (
+                    <Badge variant="outline">{info.getValue()}</Badge>
+                ),
+            }),
+            columnHelper.accessor('_nodeType', {
+                header: 'Type',
+                cell: info => {
+                    const value = info.getValue();
+                    if (value == null) return <span className="text-muted-foreground">{'\u2014'}</span>;
+                    return <Badge variant="secondary">{value}</Badge>;
+                },
+            }),
+        ],
+        [],
+    );
+
+    const table = useReactTable({
+        data: result?.hits ?? [],
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+    });
+
+    const total = result?.total ?? 0;
+    const end = Math.min(start + DEFAULT_COUNT, total);
+    const hasPrev = start > 0;
+    const hasNext = end < total;
+
     return (
         <div data-component={SEARCH_PAGE_NAME} className="p-6">
-            <h2 className="font-semibold text-2xl">Search</h2>
-            <p className="mt-2 text-muted-foreground">
-                Search nodes with NoQL here.
-            </p>
+            <div className="mb-6">
+                <h2 className="font-semibold text-2xl">Search</h2>
+                <p className="mt-1 text-muted-foreground text-sm">
+                    Search nodes across repositories using NoQL.
+                </p>
+            </div>
+
+            <div className="mb-6 space-y-4">
+                <div className="flex gap-4">
+                    <div className="w-60">
+                        <Label htmlFor="search-repo">Repository</Label>
+                        <Select value={repoId} onValueChange={handleRepoChange}>
+                            <SelectTrigger id="search-repo" className="mt-1.5">
+                                <SelectValue placeholder="All repositories" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value={ALL_REPOS}>All repositories</SelectItem>
+                                {repositories.map((repo: Repository) => (
+                                    <SelectItem key={repo.id} value={repo.id}>
+                                        {repo.id}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    {repoId !== ALL_REPOS && branches.length > 0 && (
+                        <div className="w-48">
+                            <Label htmlFor="search-branch">Branch</Label>
+                            <Select
+                                value={branch || branches[0]}
+                                onValueChange={setBranch}
+                            >
+                                <SelectTrigger id="search-branch" className="mt-1.5">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {branches.map((b: string) => (
+                                        <SelectItem key={b} value={b}>
+                                            {b}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    )}
+                </div>
+
+                <div>
+                    <Label htmlFor="search-query">NoQL Query</Label>
+                    <Textarea
+                        id="search-query"
+                        value={query}
+                        onChange={e => setQuery(e.target.value)}
+                        onKeyDown={handleKeyDown}
+                        placeholder="_name LIKE '*test*'"
+                        className="mt-1.5 font-mono text-sm"
+                        rows={3}
+                    />
+                    <p className="mt-1 text-muted-foreground text-xs">
+                        Press Ctrl+Enter to search
+                    </p>
+                </div>
+
+                <div className="flex items-center gap-2">
+                    <Button
+                        onClick={handleSubmit}
+                        disabled={query.trim() === '' || searchMutation.isPending}
+                    >
+                        {searchMutation.isPending ? (
+                            <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                            <Search className="size-4" />
+                        )}
+                        Search
+                    </Button>
+                    {(result != null || error != null) && (
+                        <Button variant="outline" onClick={handleClear}>
+                            <X className="size-4" />
+                            Clear
+                        </Button>
+                    )}
+                </div>
+            </div>
+
+            {error != null && (
+                <div className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-destructive text-sm">
+                    {error}
+                </div>
+            )}
+
+            {result != null && result.hits.length === 0 && (
+                <EmptyState
+                    icon={Search}
+                    title="No results"
+                    description="No nodes matched your query. Try adjusting your search criteria."
+                />
+            )}
+
+            {result != null && result.hits.length > 0 && (
+                <>
+                    <div className="mb-3 flex items-center justify-between">
+                        <span className="text-muted-foreground text-sm">
+                            {total.toLocaleString()} result{total !== 1 ? 's' : ''} in{' '}
+                            {result.executionTimeMs}ms
+                        </span>
+                    </div>
+
+                    <Table>
+                        <TableHeader>
+                            {table.getHeaderGroups().map(headerGroup => (
+                                <TableRow key={headerGroup.id}>
+                                    {headerGroup.headers.map(header => (
+                                        <TableHead key={header.id}>
+                                            {header.isPlaceholder
+                                                ? null
+                                                : flexRender(
+                                                      header.column.columnDef.header,
+                                                      header.getContext(),
+                                                  )}
+                                        </TableHead>
+                                    ))}
+                                </TableRow>
+                            ))}
+                        </TableHeader>
+                        <TableBody>
+                            {table.getRowModel().rows.map(row => (
+                                <TableRow key={row.id}>
+                                    {row.getVisibleCells().map(cell => (
+                                        <TableCell key={cell.id}>
+                                            {flexRender(
+                                                cell.column.columnDef.cell,
+                                                cell.getContext(),
+                                            )}
+                                        </TableCell>
+                                    ))}
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+
+                    {total > DEFAULT_COUNT && (
+                        <div className="mt-4 flex items-center justify-between">
+                            <span className="text-muted-foreground text-sm">
+                                {start + 1}&ndash;{end} of {total.toLocaleString()}
+                            </span>
+                            <div className="flex gap-2">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    disabled={!hasPrev || searchMutation.isPending}
+                                    onClick={() => doSearch(Math.max(0, start - DEFAULT_COUNT))}
+                                >
+                                    <ChevronLeft className="size-4" />
+                                    Previous
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    disabled={!hasNext || searchMutation.isPending}
+                                    onClick={() => doSearch(start + DEFAULT_COUNT)}
+                                >
+                                    Next
+                                    <ChevronRight className="size-4" />
+                                </Button>
+                            </div>
+                        </div>
+                    )}
+                </>
+            )}
         </div>
     );
 };
@@ -17,5 +381,7 @@ const SearchPage = (): ReactElement => {
 SearchPage.displayName = SEARCH_PAGE_NAME;
 
 export const Route = createFileRoute('/search')({
+    loader: ({ context: { queryClient } }) =>
+        queryClient.ensureQueryData(repositoriesQueryOptions()),
     component: SearchPage,
 });


### PR DESCRIPTION
Add search API backend with single-repo and cross-repo query support
using `connect()` and `multiRepoConnect()` respectively. Results are
enriched with node metadata (name, path, type) via grouped lookups.
The frontend provides a full search interface with repository/branch
selectors, NoQL textarea, paginated results table with score, clickable
path navigation to the node browser, and inline error display for
invalid query syntax. Execution time is measured server-side.

https://claude.ai/code/session_012idZBSrAFFRqxe7ZTvp9nT