### PR TITLE
feat: implement node actions (create, rename, move, delete, push) #10

### DIFF
--- a/src/main/resources/apis/nodes/nodes.ts
+++ b/src/main/resources/apis/nodes/nodes.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from '@enonic-types/core';
 import { connect } from '/lib/xp/node';
+import { get as getRepo } from '/lib/xp/repo';
 import { errorResponse, getParam, jsonResponse, requireAdmin } from '../../lib/api';
 
 type NodeDto = {
@@ -111,3 +112,282 @@ export function get(req: Request): Response {
 
     return getNodeList(req, repoId, branch);
 }
+
+//
+// * POST — Create node / Push node
+//
+
+function createNode(req: Request): Response {
+    const body = req.body != null ? JSON.parse(req.body as string) : {};
+    const repoId = body.repoId as string | undefined;
+    const branch = body.branch as string | undefined;
+    const parentPath = body.parentPath as string | undefined;
+    const name = body.name as string | undefined;
+    const nodeType = body.nodeType as string | undefined;
+
+    if (repoId == null) {
+        return errorResponse(400, 'Repository ID is required', 'VALIDATION_ERROR');
+    }
+    if (branch == null) {
+        return errorResponse(400, 'Branch is required', 'VALIDATION_ERROR');
+    }
+    if (name == null) {
+        return errorResponse(400, 'Node name is required', 'VALIDATION_ERROR');
+    }
+
+    try {
+        const repo = connect({ repoId, branch });
+        const created = repo.create({
+            _parentPath: parentPath || '/',
+            _name: name,
+            _nodeType: nodeType || 'default',
+        });
+
+        return jsonResponse(created, 201);
+    } catch (_e) {
+        return errorResponse(500, 'Failed to create node', 'INTERNAL_ERROR');
+    }
+}
+
+function pushNode(req: Request): Response {
+    const body = req.body != null ? JSON.parse(req.body as string) : {};
+    const repoId = body.repoId as string | undefined;
+    const branch = body.branch as string | undefined;
+    const key = body.key as string | undefined;
+    const target = body.target as string | undefined;
+    const includeChildren = body.includeChildren as boolean | undefined;
+    const resolve = body.resolve as boolean | undefined;
+
+    if (repoId == null) {
+        return errorResponse(400, 'Repository ID is required', 'VALIDATION_ERROR');
+    }
+    if (branch == null) {
+        return errorResponse(400, 'Branch is required', 'VALIDATION_ERROR');
+    }
+    if (key == null) {
+        return errorResponse(400, 'Node key is required', 'VALIDATION_ERROR');
+    }
+    if (target == null) {
+        return errorResponse(400, 'Target branch is required', 'VALIDATION_ERROR');
+    }
+
+    try {
+        const repo = connect({ repoId, branch });
+        const result = repo.push({
+            key,
+            target,
+            includeChildren: includeChildren ?? false,
+            resolve: resolve ?? true,
+        });
+
+        return jsonResponse(result);
+    } catch (_e) {
+        return errorResponse(500, 'Failed to push node', 'INTERNAL_ERROR');
+    }
+}
+
+function duplicateNode(req: Request): Response {
+    const body = req.body != null ? JSON.parse(req.body as string) : {};
+    const repoId = body.repoId as string | undefined;
+    const branch = body.branch as string | undefined;
+    const nodeId = body.nodeId as string | undefined;
+    const name = body.name as string | undefined;
+    const includeChildren = body.includeChildren as boolean | undefined;
+
+    if (repoId == null) {
+        return errorResponse(400, 'Repository ID is required', 'VALIDATION_ERROR');
+    }
+    if (branch == null) {
+        return errorResponse(400, 'Branch is required', 'VALIDATION_ERROR');
+    }
+    if (nodeId == null) {
+        return errorResponse(400, 'Node ID is required', 'VALIDATION_ERROR');
+    }
+
+    try {
+        const repo = connect({ repoId, branch });
+        const duplicated = repo.duplicate({
+            nodeId,
+            name: name || undefined,
+            includeChildren: includeChildren ?? false,
+        });
+
+        return jsonResponse(duplicated, 201);
+    } catch (_e) {
+        return errorResponse(500, 'Failed to duplicate node', 'INTERNAL_ERROR');
+    }
+}
+
+export function post(req: Request): Response {
+    const forbidden = requireAdmin();
+    if (forbidden != null) return forbidden;
+
+    const action = getParam(req, 'action');
+    if (action === 'push') return pushNode(req);
+    if (action === 'duplicate') return duplicateNode(req);
+
+    return createNode(req);
+}
+
+//
+// * PUT — Rename / Move node
+//
+
+function renameNode(req: Request): Response {
+    const body = req.body != null ? JSON.parse(req.body as string) : {};
+    const repoId = body.repoId as string | undefined;
+    const branch = body.branch as string | undefined;
+    const key = body.key as string | undefined;
+    const newName = body.newName as string | undefined;
+
+    if (repoId == null) {
+        return errorResponse(400, 'Repository ID is required', 'VALIDATION_ERROR');
+    }
+    if (branch == null) {
+        return errorResponse(400, 'Branch is required', 'VALIDATION_ERROR');
+    }
+    if (key == null) {
+        return errorResponse(400, 'Node key is required', 'VALIDATION_ERROR');
+    }
+    if (newName == null) {
+        return errorResponse(400, 'New name is required', 'VALIDATION_ERROR');
+    }
+
+    try {
+        const repo = connect({ repoId, branch });
+        const node = repo.get(key);
+        if (node == null) {
+            return errorResponse(404, `Node '${key}' not found`, 'NOT_FOUND');
+        }
+        if (node._path === '/') {
+            return errorResponse(403, 'Root node cannot be renamed', 'PROTECTED_NODE');
+        }
+
+        repo.move({ source: key, target: newName });
+        return jsonResponse({ success: true });
+    } catch (_e) {
+        return errorResponse(500, 'Failed to rename node', 'INTERNAL_ERROR');
+    }
+}
+
+function moveNode(req: Request): Response {
+    const body = req.body != null ? JSON.parse(req.body as string) : {};
+    const repoId = body.repoId as string | undefined;
+    const branch = body.branch as string | undefined;
+    const key = body.key as string | undefined;
+    const targetPath = body.targetPath as string | undefined;
+
+    if (repoId == null) {
+        return errorResponse(400, 'Repository ID is required', 'VALIDATION_ERROR');
+    }
+    if (branch == null) {
+        return errorResponse(400, 'Branch is required', 'VALIDATION_ERROR');
+    }
+    if (key == null) {
+        return errorResponse(400, 'Node key is required', 'VALIDATION_ERROR');
+    }
+    if (targetPath == null) {
+        return errorResponse(400, 'Target path is required', 'VALIDATION_ERROR');
+    }
+
+    try {
+        const repo = connect({ repoId, branch });
+        const node = repo.get(key);
+        if (node == null) {
+            return errorResponse(404, `Node '${key}' not found`, 'NOT_FOUND');
+        }
+        if (node._path === '/') {
+            return errorResponse(403, 'Root node cannot be moved', 'PROTECTED_NODE');
+        }
+
+        const targetNode = repo.get(targetPath);
+        if (targetNode == null) {
+            return errorResponse(404, `Target path '${targetPath}' not found`, 'NOT_FOUND');
+        }
+
+        repo.move({ source: key, target: targetPath });
+        return jsonResponse({ success: true });
+    } catch (_e) {
+        return errorResponse(500, 'Failed to move node', 'INTERNAL_ERROR');
+    }
+}
+
+export function put(req: Request): Response {
+    const forbidden = requireAdmin();
+    if (forbidden != null) return forbidden;
+
+    const action = getParam(req, 'action');
+    if (action === 'rename') return renameNode(req);
+    if (action === 'move') return moveNode(req);
+
+    return errorResponse(400, 'Action parameter is required (rename or move)', 'VALIDATION_ERROR');
+}
+
+//
+// * DELETE — Delete node
+//
+
+function delete_(req: Request): Response {
+    const forbidden = requireAdmin();
+    if (forbidden != null) return forbidden;
+
+    const repoId = getParam(req, 'repoId');
+    if (repoId == null) {
+        return errorResponse(400, 'Repository ID is required', 'VALIDATION_ERROR');
+    }
+
+    const branch = getParam(req, 'branch');
+    if (branch == null) {
+        return errorResponse(400, 'Branch is required', 'VALIDATION_ERROR');
+    }
+
+    const key = getParam(req, 'key');
+    if (key == null) {
+        return errorResponse(400, 'Node key is required', 'VALIDATION_ERROR');
+    }
+
+    const allBranches = getParam(req, 'allBranches') === 'true';
+
+    try {
+        const repo = connect({ repoId, branch });
+        const node = repo.get(key);
+        if (node == null) {
+            return errorResponse(404, `Node '${key}' not found`, 'NOT_FOUND');
+        }
+        if (node._path === '/') {
+            return errorResponse(403, 'Root node cannot be deleted', 'PROTECTED_NODE');
+        }
+
+        if (allBranches) {
+            const repoInfo = getRepo(repoId);
+            if (repoInfo == null) {
+                return errorResponse(404, `Repository '${repoId}' not found`, 'NOT_FOUND');
+            }
+
+            const deleted: string[] = [];
+            const failed: string[] = [];
+            for (let i = 0; i < repoInfo.branches.length; i++) {
+                const branchId = repoInfo.branches[i];
+                try {
+                    const branchRepo = connect({ repoId, branch: branchId });
+                    const branchNode = branchRepo.get(key);
+                    if (branchNode != null) {
+                        branchRepo.delete(key);
+                        deleted.push(branchId);
+                    }
+                } catch (_e) {
+                    failed.push(branchId);
+                }
+            }
+
+            return jsonResponse({ key, deleted: true, branches: { deleted, failed } });
+        }
+
+        repo.delete(key);
+        return jsonResponse({ key, deleted: true });
+    } catch (_e) {
+        return errorResponse(500, 'Failed to delete node', 'INTERNAL_ERROR');
+    }
+}
+
+export { delete_ as delete };

--- a/src/main/resources/assets/js/components/node-detail-panel.tsx
+++ b/src/main/resources/assets/js/components/node-detail-panel.tsx
@@ -1,21 +1,57 @@
 import { useQuery } from '@tanstack/react-query';
-import { Shield, Table2, X } from 'lucide-react';
+import { ArrowRightLeft, Copy, Ellipsis, Pencil, Plus, Send, Shield, Table2, Trash2, X } from 'lucide-react';
 import { type ReactElement, useEffect, useMemo, useState } from 'react';
 import { createHighlighterCore } from 'shiki/core';
 import langJson from 'shiki/dist/langs/json.mjs';
 import themeGithubDarkDefault from 'shiki/dist/themes/github-dark-default.mjs';
 import themeGithubLightDefault from 'shiki/dist/themes/github-light-default.mjs';
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
+import { branchesQueryOptions } from '../lib/api/branches';
 import {
     type AccessControlEntry,
     type NodeDetail,
     type NodeDetailParams,
     nodeDetailQueryOptions,
+    useCreateNode,
+    useDeleteNode,
+    useDuplicateNode,
+    useMoveNode,
+    usePushNode,
+    useRenameNode,
 } from '../lib/api/nodes';
 import { cn } from '../lib/utils';
 import { useTheme } from './theme-provider';
 import { Badge } from './ui/badge';
+import { Button } from './ui/button';
+import { Checkbox } from './ui/checkbox';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from './ui/dialog';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuGroup,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from './ui/dropdown-menu';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from './ui/select';
 import { Skeleton } from './ui/skeleton';
+import { toast } from './ui/sonner';
 import {
     Table,
     TableBody,
@@ -41,6 +77,7 @@ export type NodeDetailPanelProps = {
     repoId: string;
     branch: string;
     onClose: () => void;
+    onNodeMutated?: () => void;
 };
 
 //
@@ -333,6 +370,418 @@ const JsonTab = ({ node }: { node: NodeDetail }): ReactElement => {
 JsonTab.displayName = JSON_TAB_NAME;
 
 //
+// * PanelActions
+//
+
+type PanelActionsProps = {
+    node: NodeDetail;
+    repoId: string;
+    branch: string;
+    onNodeMutated?: () => void;
+};
+
+const PanelActions = ({ node, repoId, branch, onNodeMutated }: PanelActionsProps): ReactElement => {
+    const [createOpen, setCreateOpen] = useState(false);
+    const [renameOpen, setRenameOpen] = useState(false);
+    const [moveOpen, setMoveOpen] = useState(false);
+    const [pushOpen, setPushOpen] = useState(false);
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const [deleteAllBranches, setDeleteAllBranches] = useState(false);
+
+    const [createName, setCreateName] = useState('');
+    const [createType, setCreateType] = useState('');
+    const [createError, setCreateError] = useState<string | undefined>();
+    const [renameName, setRenameName] = useState(node._name);
+    const [renameError, setRenameError] = useState<string | undefined>();
+    const [movePath, setMovePath] = useState('');
+    const [moveError, setMoveError] = useState<string | undefined>();
+    const [pushTarget, setPushTarget] = useState('');
+    const [pushChildren, setPushChildren] = useState(false);
+    const [pushResolve, setPushResolve] = useState(true);
+
+    const createMutation = useCreateNode();
+    const renameMutation = useRenameNode();
+    const moveMutation = useMoveNode();
+    const pushMutation = usePushNode();
+    const duplicateMutation = useDuplicateNode();
+    const deleteMutation = useDeleteNode();
+
+    const { data: branches } = useQuery(branchesQueryOptions(repoId));
+    const availableBranches = branches?.filter(b => b.id !== branch) ?? [];
+
+    const isRoot = node._path === '/';
+
+    const handleDuplicate = () => {
+        duplicateMutation.mutate(
+            { repoId, branch, nodeId: node._id },
+            {
+                onSuccess: (result) => {
+                    toast.success(`Node duplicated as '${result._name}'`);
+                },
+                onError: () => toast.error(`Failed to duplicate node '${node._name}'`),
+            },
+        );
+    };
+
+    const handleCreate = () => {
+        if (createName.trim() === '') {
+            setCreateError('Name is required');
+            return;
+        }
+        if (createName.includes('/')) {
+            setCreateError('Name cannot contain slashes');
+            return;
+        }
+        createMutation.mutate(
+            { repoId, branch, parentPath: node._path, name: createName, nodeType: createType.trim() || undefined },
+            {
+                onSuccess: () => {
+                    toast.success(`Node '${createName}' created`);
+                    setCreateOpen(false);
+                    setCreateName('');
+                    setCreateType('');
+                    setCreateError(undefined);
+                },
+                onError: () => toast.error(`Failed to create node '${createName}'`),
+            },
+        );
+    };
+
+    const handleRename = () => {
+        if (renameName.trim() === '') {
+            setRenameError('Name is required');
+            return;
+        }
+        if (renameName.includes('/')) {
+            setRenameError('Name cannot contain slashes');
+            return;
+        }
+        if (renameName === node._name) {
+            setRenameError('Name must be different from current');
+            return;
+        }
+        renameMutation.mutate(
+            { repoId, branch, key: node._id, newName: renameName },
+            {
+                onSuccess: () => {
+                    toast.success(`Node renamed to '${renameName}'`);
+                    setRenameOpen(false);
+                },
+                onError: () => toast.error('Failed to rename node'),
+            },
+        );
+    };
+
+    const handleMove = () => {
+        if (movePath.trim() === '') {
+            setMoveError('Target path is required');
+            return;
+        }
+        if (!movePath.startsWith('/')) {
+            setMoveError('Path must start with /');
+            return;
+        }
+        moveMutation.mutate(
+            { repoId, branch, key: node._id, targetPath: movePath },
+            {
+                onSuccess: () => {
+                    toast.success(`Node moved to '${movePath}'`);
+                    setMoveOpen(false);
+                    onNodeMutated?.();
+                },
+                onError: () => toast.error('Failed to move node'),
+            },
+        );
+    };
+
+    const handlePush = () => {
+        if (pushTarget === '') return;
+        pushMutation.mutate(
+            { repoId, branch, key: node._id, target: pushTarget, includeChildren: pushChildren, resolve: pushResolve },
+            {
+                onSuccess: (result) => {
+                    const failedCount = result.failed.length;
+                    if (failedCount > 0) {
+                        toast.warning(`Pushed to '${pushTarget}': ${result.success.length} succeeded, ${failedCount} failed`);
+                    } else {
+                        toast.success(`Pushed to '${pushTarget}': ${result.success.length} nodes`);
+                    }
+                    setPushOpen(false);
+                },
+                onError: () => toast.error('Failed to push node'),
+            },
+        );
+    };
+
+    const handleDelete = () => {
+        deleteMutation.mutate(
+            { repoId, branch, key: node._id, allBranches: deleteAllBranches || undefined },
+            {
+                onSuccess: (result) => {
+                    if (result.branches != null) {
+                        const count = result.branches.deleted.length;
+                        toast.success(`Node '${node._name}' deleted from ${count} branch${count !== 1 ? 'es' : ''}`);
+                    } else {
+                        toast.success(`Node '${node._name}' deleted`);
+                    }
+                    setDeleteOpen(false);
+                    setDeleteAllBranches(false);
+                    onNodeMutated?.();
+                },
+                onError: () => toast.error(`Failed to delete node '${node._name}'`),
+            },
+        );
+    };
+
+    return (
+        <>
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <button
+                        type="button"
+                        className={cn(
+                            'ml-1 flex size-7 shrink-0 items-center justify-center rounded-md',
+                            'text-muted-foreground transition-colors',
+                            'hover:bg-accent hover:text-accent-foreground',
+                        )}
+                        aria-label="Node actions"
+                    >
+                        <Ellipsis className="size-4" />
+                    </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                    <DropdownMenuGroup>
+                        <DropdownMenuItem onClick={() => setCreateOpen(true)}>
+                            <Plus className="size-4" />
+                            Create Child
+                        </DropdownMenuItem>
+                    </DropdownMenuGroup>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuGroup>
+                        <DropdownMenuItem disabled={isRoot} onClick={() => {
+                            setRenameName(node._name);
+                            setRenameOpen(true);
+                        }}>
+                            <Pencil className="size-4" />
+                            Rename
+                        </DropdownMenuItem>
+                        <DropdownMenuItem disabled={isRoot} onClick={() => setMoveOpen(true)}>
+                            <ArrowRightLeft className="size-4" />
+                            Move
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={handleDuplicate}>
+                            <Copy className="size-4" />
+                            Duplicate
+                        </DropdownMenuItem>
+                    </DropdownMenuGroup>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuGroup>
+                        <DropdownMenuItem onClick={() => setPushOpen(true)}>
+                            <Send className="size-4" />
+                            Push
+                        </DropdownMenuItem>
+                    </DropdownMenuGroup>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuGroup>
+                        <DropdownMenuItem
+                            disabled={isRoot}
+                            className="text-destructive focus:text-destructive"
+                            onClick={() => setDeleteOpen(true)}
+                        >
+                            <Trash2 className="size-4" />
+                            Delete
+                        </DropdownMenuItem>
+                    </DropdownMenuGroup>
+                </DropdownMenuContent>
+            </DropdownMenu>
+
+            {/* Create Child Dialog */}
+            <Dialog open={createOpen} onOpenChange={open => {
+                setCreateOpen(open);
+                if (!open) { setCreateName(''); setCreateType(''); setCreateError(undefined); }
+            }}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Create Child Node</DialogTitle>
+                        <DialogDescription>
+                            Create a new child node under &apos;{node._path}&apos;.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="grid gap-4 py-4">
+                        <div className="grid gap-2">
+                            <Label htmlFor="panel-create-name">Name</Label>
+                            <Input
+                                id="panel-create-name"
+                                value={createName}
+                                onChange={e => { setCreateName(e.target.value); setCreateError(undefined); }}
+                                onKeyDown={e => { if (e.key === 'Enter') handleCreate(); }}
+                                placeholder="my-node"
+                            />
+                            {createError != null && <p className="text-destructive text-sm">{createError}</p>}
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="panel-create-type">Node Type</Label>
+                            <Input
+                                id="panel-create-type"
+                                value={createType}
+                                onChange={e => setCreateType(e.target.value)}
+                                placeholder="default"
+                            />
+                        </div>
+                    </div>
+                    <DialogFooter>
+                        <DialogClose asChild><Button>Cancel</Button></DialogClose>
+                        <Button variant="primary" onClick={handleCreate} disabled={createMutation.isPending}>Create</Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Rename Dialog */}
+            <Dialog open={renameOpen} onOpenChange={open => {
+                setRenameOpen(open);
+                if (!open) { setRenameName(node._name); setRenameError(undefined); }
+            }}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Rename Node</DialogTitle>
+                        <DialogDescription>Enter a new name for &apos;{node._name}&apos;.</DialogDescription>
+                    </DialogHeader>
+                    <div className="grid gap-2 py-4">
+                        <Label htmlFor="panel-rename-name">Name</Label>
+                        <Input
+                            id="panel-rename-name"
+                            value={renameName}
+                            onChange={e => { setRenameName(e.target.value); setRenameError(undefined); }}
+                            onKeyDown={e => { if (e.key === 'Enter') handleRename(); }}
+                        />
+                        {renameError != null && <p className="text-destructive text-sm">{renameError}</p>}
+                    </div>
+                    <DialogFooter>
+                        <DialogClose asChild><Button>Cancel</Button></DialogClose>
+                        <Button variant="primary" onClick={handleRename} disabled={renameMutation.isPending}>Rename</Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Move Dialog */}
+            <Dialog open={moveOpen} onOpenChange={open => {
+                setMoveOpen(open);
+                if (!open) { setMovePath(''); setMoveError(undefined); }
+            }}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Move Node</DialogTitle>
+                        <DialogDescription>Move &apos;{node._name}&apos; to a new parent path.</DialogDescription>
+                    </DialogHeader>
+                    <div className="grid gap-4 py-4">
+                        <div className="grid gap-1">
+                            <Label className="text-muted-foreground">Current Path</Label>
+                            <button
+                                type="button"
+                                className="cursor-pointer truncate text-left font-mono text-sm hover:text-foreground"
+                                title="Click to copy path"
+                                onClick={() => {
+                                    navigator.clipboard.writeText(node._path);
+                                    toast.success('Path copied to clipboard');
+                                }}
+                            >
+                                {node._path}
+                            </button>
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="panel-move-path">Target Path</Label>
+                            <Input
+                                id="panel-move-path"
+                                value={movePath}
+                                onChange={e => { setMovePath(e.target.value); setMoveError(undefined); }}
+                                onKeyDown={e => { if (e.key === 'Enter') handleMove(); }}
+                                placeholder="/target/path"
+                            />
+                            {moveError != null && <p className="text-destructive text-sm">{moveError}</p>}
+                        </div>
+                    </div>
+                    <DialogFooter>
+                        <DialogClose asChild><Button>Cancel</Button></DialogClose>
+                        <Button variant="primary" onClick={handleMove} disabled={moveMutation.isPending}>Move</Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Push Dialog */}
+            <Dialog open={pushOpen} onOpenChange={open => {
+                setPushOpen(open);
+                if (!open) { setPushTarget(''); setPushChildren(false); setPushResolve(true); }
+            }}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Push Node</DialogTitle>
+                        <DialogDescription>Push &apos;{node._name}&apos; to another branch.</DialogDescription>
+                    </DialogHeader>
+                    <div className="grid gap-4 py-4">
+                        <div className="grid gap-2">
+                            <Label>Target Branch</Label>
+                            <Select value={pushTarget} onValueChange={setPushTarget}>
+                                <SelectTrigger>
+                                    <SelectValue placeholder="Select branch" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {availableBranches.map(b => (
+                                        <SelectItem key={b.id} value={b.id}>{b.id}</SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <Checkbox id="panel-push-children" checked={pushChildren} onCheckedChange={checked => setPushChildren(checked === true)} />
+                            <Label htmlFor="panel-push-children" className="font-normal">Include children</Label>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <Checkbox id="panel-push-resolve" checked={pushResolve} onCheckedChange={checked => setPushResolve(checked === true)} />
+                            <Label htmlFor="panel-push-resolve" className="font-normal">Resolve dependencies</Label>
+                        </div>
+                    </div>
+                    <DialogFooter>
+                        <DialogClose asChild><Button>Cancel</Button></DialogClose>
+                        <Button variant="primary" onClick={handlePush} disabled={pushMutation.isPending || pushTarget === ''}>Push</Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Delete Confirm */}
+            <Dialog open={deleteOpen} onOpenChange={open => {
+                setDeleteOpen(open);
+                if (!open) setDeleteAllBranches(false);
+            }}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Delete Node</DialogTitle>
+                        <DialogDescription>
+                            Are you sure you want to delete &apos;{node._name}&apos; ({node._path})? This action cannot be undone.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="flex items-center gap-2 py-2">
+                        <Checkbox
+                            id="panel-delete-all"
+                            checked={deleteAllBranches}
+                            onCheckedChange={checked => setDeleteAllBranches(checked === true)}
+                        />
+                        <Label htmlFor="panel-delete-all" className="font-normal">
+                            Delete from all branches
+                        </Label>
+                    </div>
+                    <DialogFooter>
+                        <DialogClose asChild><Button>Cancel</Button></DialogClose>
+                        <Button variant="destructive" onClick={handleDelete} disabled={deleteMutation.isPending}>
+                            Delete
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+};
+
+//
 // * NodeDetailContent
 //
 
@@ -341,9 +790,11 @@ const NODE_DETAIL_CONTENT_NAME = 'NodeDetailContent';
 const NodeDetailContent = ({
     params,
     onClose,
+    onNodeMutated,
 }: {
     params: NodeDetailParams;
     onClose: () => void;
+    onNodeMutated?: () => void;
 }): ReactElement => {
     const { data: node, isLoading, error } = useQuery(nodeDetailQueryOptions(params));
 
@@ -383,18 +834,26 @@ const NodeDetailContent = ({
                         {node._path}
                     </p>
                 </div>
-                <button
-                    type="button"
-                    onClick={onClose}
-                    className={cn(
-                        'ml-2 flex size-7 shrink-0 items-center justify-center rounded-md',
-                        'text-muted-foreground transition-colors',
-                        'hover:bg-accent hover:text-accent-foreground',
-                    )}
-                    aria-label="Close panel"
-                >
-                    <X className="size-4" />
-                </button>
+                <div className="flex shrink-0 items-center">
+                    <PanelActions
+                        node={node}
+                        repoId={params.repoId}
+                        branch={params.branch}
+                        onNodeMutated={onNodeMutated}
+                    />
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className={cn(
+                            'ml-1 flex size-7 shrink-0 items-center justify-center rounded-md',
+                            'text-muted-foreground transition-colors',
+                            'hover:bg-accent hover:text-accent-foreground',
+                        )}
+                        aria-label="Close panel"
+                    >
+                        <X className="size-4" />
+                    </button>
+                </div>
             </div>
 
             {/* Tabs */}
@@ -439,6 +898,7 @@ export const NodeDetailPanel = ({
     repoId,
     branch,
     onClose,
+    onNodeMutated,
 }: NodeDetailPanelProps): ReactElement => {
     return (
         <div
@@ -448,6 +908,7 @@ export const NodeDetailPanel = ({
             <NodeDetailContent
                 params={{ repoId, branch, key: nodeId }}
                 onClose={onClose}
+                onNodeMutated={onNodeMutated}
             />
         </div>
     );

--- a/src/main/resources/assets/js/components/ui/alert-dialog.tsx
+++ b/src/main/resources/assets/js/components/ui/alert-dialog.tsx
@@ -1,7 +1,11 @@
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
-import type { ComponentProps, ReactElement } from 'react';
+import type { ComponentProps, MouseEvent, ReactElement } from 'react';
 import { cn } from '../../lib/utils';
 import { buttonVariants } from './button';
+
+// Prevents React synthetic events from portaled content from bubbling
+// through the React component tree to ancestors (e.g. table row onClick).
+const stopPropagation = (e: MouseEvent) => e.stopPropagation();
 
 //
 // * AlertDialog
@@ -55,11 +59,12 @@ const ALERT_DIALOG_CONTENT_NAME = 'AlertDialogContent';
 export const AlertDialogContent = ({
     ref,
     className,
+    onClick,
     ...props
 }: ComponentProps<typeof AlertDialogPrimitive.Content>): ReactElement => {
     return (
         <AlertDialogPortal>
-            <AlertDialogOverlay />
+            <AlertDialogOverlay onClick={stopPropagation} />
             <AlertDialogPrimitive.Content
                 ref={ref}
                 data-component={ALERT_DIALOG_CONTENT_NAME}
@@ -67,6 +72,10 @@ export const AlertDialogContent = ({
                     'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg',
                     className,
                 )}
+                onClick={e => {
+                    stopPropagation(e);
+                    onClick?.(e);
+                }}
                 {...props}
             />
         </AlertDialogPortal>

--- a/src/main/resources/assets/js/components/ui/dialog.tsx
+++ b/src/main/resources/assets/js/components/ui/dialog.tsx
@@ -1,7 +1,11 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
-import type { ComponentProps, ReactElement } from 'react';
+import type { ComponentProps, MouseEvent, ReactElement } from 'react';
 import { cn } from '../../lib/utils';
+
+// Prevents React synthetic events from portaled content from bubbling
+// through the React component tree to ancestors (e.g. table row onClick).
+const stopPropagation = (e: MouseEvent) => e.stopPropagation();
 
 //
 // * Dialog
@@ -62,11 +66,12 @@ export const DialogContent = ({
     ref,
     className,
     children,
+    onClick,
     ...props
 }: ComponentProps<typeof DialogPrimitive.Content>): ReactElement => {
     return (
         <DialogPortal>
-            <DialogOverlay />
+            <DialogOverlay onClick={stopPropagation} />
             <DialogPrimitive.Content
                 ref={ref}
                 data-component={DIALOG_CONTENT_NAME}
@@ -74,6 +79,10 @@ export const DialogContent = ({
                     'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg',
                     className,
                 )}
+                onClick={e => {
+                    stopPropagation(e);
+                    onClick?.(e);
+                }}
                 {...props}
             >
                 {children}

--- a/src/main/resources/assets/js/lib/api/nodes.ts
+++ b/src/main/resources/assets/js/lib/api/nodes.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from '@tanstack/react-query';
+import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getConfig } from '../config';
 import { apiFetch } from './client';
 
@@ -103,5 +103,185 @@ export function nodeDetailQueryOptions(params: NodeDetailParams) {
     return queryOptions({
         queryKey: ['node-detail', params.repoId, params.branch, params.key],
         queryFn: () => fetchNodeDetail(params),
+    });
+}
+
+//
+// * Node Mutations
+//
+
+export type CreateNodeParams = {
+    repoId: string;
+    branch: string;
+    parentPath: string;
+    name: string;
+    nodeType?: string;
+};
+
+export type RenameNodeParams = {
+    repoId: string;
+    branch: string;
+    key: string;
+    newName: string;
+};
+
+export type MoveNodeParams = {
+    repoId: string;
+    branch: string;
+    key: string;
+    targetPath: string;
+};
+
+export type DeleteNodeParams = {
+    repoId: string;
+    branch: string;
+    key: string;
+    allBranches?: boolean;
+};
+
+export type PushNodeParams = {
+    repoId: string;
+    branch: string;
+    key: string;
+    target: string;
+    includeChildren?: boolean;
+    resolve?: boolean;
+};
+
+export type PushNodeResult = {
+    success: string[];
+    failed: { id: string; reason: string }[];
+    deleted: string[];
+};
+
+export type DuplicateNodeParams = {
+    repoId: string;
+    branch: string;
+    nodeId: string;
+    name?: string;
+    includeChildren?: boolean;
+};
+
+export function createNode(params: CreateNodeParams): Promise<NodeDetail> {
+    const { apiUris } = getConfig();
+    return apiFetch<NodeDetail>(apiUris.nodes, {
+        method: 'POST',
+        body: params,
+    });
+}
+
+export function renameNode(params: RenameNodeParams): Promise<{ success: boolean }> {
+    const { apiUris } = getConfig();
+    return apiFetch<{ success: boolean }>(apiUris.nodes, {
+        method: 'PUT',
+        params: { action: 'rename' },
+        body: params,
+    });
+}
+
+export function moveNode(params: MoveNodeParams): Promise<{ success: boolean }> {
+    const { apiUris } = getConfig();
+    return apiFetch<{ success: boolean }>(apiUris.nodes, {
+        method: 'PUT',
+        params: { action: 'move' },
+        body: params,
+    });
+}
+
+export type DeleteNodeResult = {
+    key: string;
+    deleted: boolean;
+    branches?: { deleted: string[]; failed: string[] };
+};
+
+export function deleteNode(params: DeleteNodeParams): Promise<DeleteNodeResult> {
+    const { apiUris } = getConfig();
+    const queryParams: Record<string, string> = {
+        repoId: params.repoId,
+        branch: params.branch,
+        key: params.key,
+    };
+    if (params.allBranches) {
+        queryParams.allBranches = 'true';
+    }
+    return apiFetch<DeleteNodeResult>(apiUris.nodes, {
+        method: 'DELETE',
+        params: queryParams,
+    });
+}
+
+export function pushNode(params: PushNodeParams): Promise<PushNodeResult> {
+    const { apiUris } = getConfig();
+    return apiFetch<PushNodeResult>(apiUris.nodes, {
+        method: 'POST',
+        params: { action: 'push' },
+        body: params,
+    });
+}
+
+export function duplicateNode(params: DuplicateNodeParams): Promise<NodeDetail> {
+    const { apiUris } = getConfig();
+    return apiFetch<NodeDetail>(apiUris.nodes, {
+        method: 'POST',
+        params: { action: 'duplicate' },
+        body: params,
+    });
+}
+
+export function useCreateNode() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: createNode,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['nodes'] });
+        },
+    });
+}
+
+export function useRenameNode() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: renameNode,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['nodes'] });
+            queryClient.invalidateQueries({ queryKey: ['node-detail'] });
+        },
+    });
+}
+
+export function useMoveNode() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: moveNode,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['nodes'] });
+            queryClient.invalidateQueries({ queryKey: ['node-detail'] });
+        },
+    });
+}
+
+export function useDeleteNode() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: deleteNode,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['nodes'] });
+        },
+    });
+}
+
+export function usePushNode() {
+    return useMutation({
+        mutationFn: pushNode,
+    });
+}
+
+export function useDuplicateNode() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: duplicateNode,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['nodes'] });
+        },
     });
 }

--- a/src/main/resources/assets/js/routes/repositories.$repoId.$branch.tsx
+++ b/src/main/resources/assets/js/routes/repositories.$repoId.$branch.tsx
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import {
     createColumnHelper,
@@ -6,21 +6,43 @@ import {
     getCoreRowModel,
     useReactTable,
 } from '@tanstack/react-table';
-import { ArrowLeft, ChevronLeft, ChevronRight, Ellipsis, Eye, FileText, Folder, FolderOpen, LayoutGrid, LayoutList, Plus } from 'lucide-react';
+import { ArrowLeft, ArrowRightLeft, ChevronLeft, ChevronRight, Copy, Ellipsis, Eye, FileText, Folder, FolderOpen, LayoutGrid, LayoutList, Pencil, Plus, Send, Trash2 } from 'lucide-react';
 import { Fragment, type ReactElement, useState } from 'react';
 import { z } from 'zod';
 import { NodeDetailPanel } from '../components/node-detail-panel';
 import { Badge } from '../components/ui/badge';
 import { Button } from '../components/ui/button';
+import { Checkbox } from '../components/ui/checkbox';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '../components/ui/dialog';
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuGroup,
     DropdownMenuItem,
+    DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '../components/ui/dropdown-menu';
 import { EmptyState } from '../components/ui/empty-state';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '../components/ui/select';
 import { Separator } from '../components/ui/separator';
+import { toast } from '../components/ui/sonner';
 import {
     Table,
     TableBody,
@@ -29,7 +51,17 @@ import {
     TableHeader,
     TableRow,
 } from '../components/ui/table';
-import { type NodeEntry, nodesQueryOptions } from '../lib/api/nodes';
+import { branchesQueryOptions } from '../lib/api/branches';
+import {
+    type NodeEntry,
+    nodesQueryOptions,
+    useCreateNode,
+    useDeleteNode,
+    useDuplicateNode,
+    useMoveNode,
+    usePushNode,
+    useRenameNode,
+} from '../lib/api/nodes';
 import { cn } from '../lib/utils';
 
 const NODE_BROWSER_PAGE_NAME = 'NodeBrowserPage';
@@ -135,6 +167,646 @@ const BreadcrumbToolbar = ({
 BreadcrumbToolbar.displayName = BREADCRUMB_TOOLBAR_NAME;
 
 //
+// * RenameDialog
+//
+
+type RenameDialogProps = {
+    node: NodeEntry;
+    repoId: string;
+    branch: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+};
+
+const RenameDialog = ({ node, repoId, branch, open, onOpenChange }: RenameDialogProps): ReactElement => {
+    const [name, setName] = useState(node._name);
+    const [error, setError] = useState<string | undefined>();
+    const renameMutation = useRenameNode();
+
+    const handleSubmit = () => {
+        if (name.trim() === '') {
+            setError('Name is required');
+            return;
+        }
+        if (name.includes('/')) {
+            setError('Name cannot contain slashes');
+            return;
+        }
+        if (name === node._name) {
+            setError('Name must be different from current');
+            return;
+        }
+
+        renameMutation.mutate(
+            { repoId, branch, key: node._id, newName: name },
+            {
+                onSuccess: () => {
+                    toast.success(`Node renamed to '${name}'`);
+                    onOpenChange(false);
+                },
+                onError: () => {
+                    toast.error('Failed to rename node');
+                },
+            },
+        );
+    };
+
+    const handleOpenChange = (nextOpen: boolean) => {
+        onOpenChange(nextOpen);
+        if (!nextOpen) {
+            setName(node._name);
+            setError(undefined);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Rename Node</DialogTitle>
+                    <DialogDescription>
+                        Enter a new name for &apos;{node._name}&apos;.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="grid gap-2 py-4">
+                    <Label htmlFor="rename-name">Name</Label>
+                    <Input
+                        id="rename-name"
+                        value={name}
+                        onChange={e => {
+                            setName(e.target.value);
+                            setError(undefined);
+                        }}
+                        onKeyDown={e => {
+                            if (e.key === 'Enter') handleSubmit();
+                        }}
+                    />
+                    {error != null && (
+                        <p className="text-destructive text-sm">{error}</p>
+                    )}
+                </div>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button>Cancel</Button>
+                    </DialogClose>
+                    <Button
+                        variant="primary"
+                        onClick={handleSubmit}
+                        disabled={renameMutation.isPending}
+                    >
+                        Rename
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+//
+// * MoveDialog
+//
+
+type MoveDialogProps = {
+    node: NodeEntry;
+    repoId: string;
+    branch: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+};
+
+const MoveDialog = ({ node, repoId, branch, open, onOpenChange }: MoveDialogProps): ReactElement => {
+    const [targetPath, setTargetPath] = useState('');
+    const [error, setError] = useState<string | undefined>();
+    const moveMutation = useMoveNode();
+
+    const handleSubmit = () => {
+        if (targetPath.trim() === '') {
+            setError('Target path is required');
+            return;
+        }
+        if (!targetPath.startsWith('/')) {
+            setError('Path must start with /');
+            return;
+        }
+
+        moveMutation.mutate(
+            { repoId, branch, key: node._id, targetPath },
+            {
+                onSuccess: () => {
+                    toast.success(`Node moved to '${targetPath}'`);
+                    onOpenChange(false);
+                },
+                onError: () => {
+                    toast.error('Failed to move node');
+                },
+            },
+        );
+    };
+
+    const handleOpenChange = (nextOpen: boolean) => {
+        onOpenChange(nextOpen);
+        if (!nextOpen) {
+            setTargetPath('');
+            setError(undefined);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Move Node</DialogTitle>
+                    <DialogDescription>
+                        Move &apos;{node._name}&apos; to a new parent path.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="grid gap-4 py-4">
+                    <div className="grid gap-1">
+                        <Label className="text-muted-foreground">Current Path</Label>
+                        <button
+                            type="button"
+                            className="cursor-pointer truncate text-left font-mono text-sm hover:text-foreground"
+                            title="Click to copy path"
+                            onClick={() => {
+                                navigator.clipboard.writeText(node._path);
+                                toast.success('Path copied to clipboard');
+                            }}
+                        >
+                            {node._path}
+                        </button>
+                    </div>
+                    <div className="grid gap-2">
+                        <Label htmlFor="move-path">Target Path</Label>
+                        <Input
+                            id="move-path"
+                            value={targetPath}
+                            onChange={e => {
+                                setTargetPath(e.target.value);
+                                setError(undefined);
+                            }}
+                            onKeyDown={e => {
+                                if (e.key === 'Enter') handleSubmit();
+                            }}
+                            placeholder="/target/path"
+                        />
+                        {error != null && (
+                            <p className="text-destructive text-sm">{error}</p>
+                        )}
+                    </div>
+                </div>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button>Cancel</Button>
+                    </DialogClose>
+                    <Button
+                        variant="primary"
+                        onClick={handleSubmit}
+                        disabled={moveMutation.isPending}
+                    >
+                        Move
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+//
+// * PushDialog
+//
+
+type PushDialogProps = {
+    node: NodeEntry;
+    repoId: string;
+    branch: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+};
+
+const PushDialog = ({ node, repoId, branch, open, onOpenChange }: PushDialogProps): ReactElement => {
+    const [target, setTarget] = useState('');
+    const [includeChildren, setIncludeChildren] = useState(false);
+    const [resolve, setResolve] = useState(true);
+    const pushMutation = usePushNode();
+
+    const { data: branches } = useQuery(branchesQueryOptions(repoId));
+    const availableBranches = branches?.filter(b => b.id !== branch) ?? [];
+
+    const handleSubmit = () => {
+        if (target === '') return;
+
+        pushMutation.mutate(
+            { repoId, branch, key: node._id, target, includeChildren, resolve },
+            {
+                onSuccess: (result) => {
+                    const successCount = result.success.length;
+                    const failedCount = result.failed.length;
+                    if (failedCount > 0) {
+                        toast.warning(`Pushed to '${target}': ${successCount} succeeded, ${failedCount} failed`);
+                    } else {
+                        toast.success(`Pushed to '${target}': ${successCount} nodes`);
+                    }
+                    onOpenChange(false);
+                },
+                onError: () => {
+                    toast.error('Failed to push node');
+                },
+            },
+        );
+    };
+
+    const handleOpenChange = (nextOpen: boolean) => {
+        onOpenChange(nextOpen);
+        if (!nextOpen) {
+            setTarget('');
+            setIncludeChildren(false);
+            setResolve(true);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Push Node</DialogTitle>
+                    <DialogDescription>
+                        Push &apos;{node._name}&apos; to another branch.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="grid gap-4 py-4">
+                    <div className="grid gap-2">
+                        <Label>Target Branch</Label>
+                        <Select value={target} onValueChange={setTarget}>
+                            <SelectTrigger>
+                                <SelectValue placeholder="Select branch" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {availableBranches.map(b => (
+                                    <SelectItem key={b.id} value={b.id}>
+                                        {b.id}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Checkbox
+                            id="push-children"
+                            checked={includeChildren}
+                            onCheckedChange={checked => setIncludeChildren(checked === true)}
+                        />
+                        <Label htmlFor="push-children" className="font-normal">
+                            Include children
+                        </Label>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Checkbox
+                            id="push-resolve"
+                            checked={resolve}
+                            onCheckedChange={checked => setResolve(checked === true)}
+                        />
+                        <Label htmlFor="push-resolve" className="font-normal">
+                            Resolve dependencies
+                        </Label>
+                    </div>
+                </div>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button>Cancel</Button>
+                    </DialogClose>
+                    <Button
+                        variant="primary"
+                        onClick={handleSubmit}
+                        disabled={pushMutation.isPending || target === ''}
+                    >
+                        Push
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+//
+// * RowActions
+//
+
+type RowActionsProps = {
+    node: NodeEntry;
+    repoId: string;
+    branch: string;
+    onPreview: (id: string) => void;
+    onDeleted?: () => void;
+};
+
+const RowActions = ({ node, repoId, branch, onPreview, onDeleted }: RowActionsProps): ReactElement => {
+    const [renameOpen, setRenameOpen] = useState(false);
+    const [moveOpen, setMoveOpen] = useState(false);
+    const [pushOpen, setPushOpen] = useState(false);
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const [deleteAllBranches, setDeleteAllBranches] = useState(false);
+    const duplicateMutation = useDuplicateNode();
+    const deleteMutation = useDeleteNode();
+
+    const handleDuplicate = () => {
+        duplicateMutation.mutate(
+            { repoId, branch, nodeId: node._id },
+            {
+                onSuccess: (result) => {
+                    toast.success(`Node duplicated as '${result._name}'`);
+                },
+                onError: () => {
+                    toast.error(`Failed to duplicate node '${node._name}'`);
+                },
+            },
+        );
+    };
+
+    const handleDelete = () => {
+        deleteMutation.mutate(
+            { repoId, branch, key: node._id, allBranches: deleteAllBranches || undefined },
+            {
+                onSuccess: (result) => {
+                    if (result.branches != null) {
+                        const count = result.branches.deleted.length;
+                        toast.success(`Node '${node._name}' deleted from ${count} branch${count !== 1 ? 'es' : ''}`);
+                    } else {
+                        toast.success(`Node '${node._name}' deleted`);
+                    }
+                    setDeleteOpen(false);
+                    setDeleteAllBranches(false);
+                    onDeleted?.();
+                },
+                onError: () => {
+                    toast.error(`Failed to delete node '${node._name}'`);
+                },
+            },
+        );
+    };
+
+    return (
+        <>
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={e => e.stopPropagation()}
+                    >
+                        <Ellipsis className="size-4 text-muted-foreground" />
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                    <DropdownMenuGroup>
+                        <DropdownMenuItem
+                            onClick={e => {
+                                e.stopPropagation();
+                                onPreview(node._id);
+                            }}
+                        >
+                            <Eye className="size-4" />
+                            Preview
+                        </DropdownMenuItem>
+                    </DropdownMenuGroup>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuGroup>
+                        <DropdownMenuItem
+                            onClick={e => {
+                                e.stopPropagation();
+                                setRenameOpen(true);
+                            }}
+                        >
+                            <Pencil className="size-4" />
+                            Rename
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                            onClick={e => {
+                                e.stopPropagation();
+                                setMoveOpen(true);
+                            }}
+                        >
+                            <ArrowRightLeft className="size-4" />
+                            Move
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                            onClick={e => {
+                                e.stopPropagation();
+                                handleDuplicate();
+                            }}
+                        >
+                            <Copy className="size-4" />
+                            Duplicate
+                        </DropdownMenuItem>
+                    </DropdownMenuGroup>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuGroup>
+                        <DropdownMenuItem
+                            onClick={e => {
+                                e.stopPropagation();
+                                setPushOpen(true);
+                            }}
+                        >
+                            <Send className="size-4" />
+                            Push
+                        </DropdownMenuItem>
+                    </DropdownMenuGroup>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuGroup>
+                        <DropdownMenuItem
+                            className="text-destructive focus:text-destructive"
+                            onClick={e => {
+                                e.stopPropagation();
+                                setDeleteOpen(true);
+                            }}
+                        >
+                            <Trash2 className="size-4" />
+                            Delete
+                        </DropdownMenuItem>
+                    </DropdownMenuGroup>
+                </DropdownMenuContent>
+            </DropdownMenu>
+
+            <RenameDialog
+                node={node}
+                repoId={repoId}
+                branch={branch}
+                open={renameOpen}
+                onOpenChange={setRenameOpen}
+            />
+            <MoveDialog
+                node={node}
+                repoId={repoId}
+                branch={branch}
+                open={moveOpen}
+                onOpenChange={setMoveOpen}
+            />
+            <PushDialog
+                node={node}
+                repoId={repoId}
+                branch={branch}
+                open={pushOpen}
+                onOpenChange={setPushOpen}
+            />
+            <Dialog open={deleteOpen} onOpenChange={open => {
+                setDeleteOpen(open);
+                if (!open) setDeleteAllBranches(false);
+            }}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Delete Node</DialogTitle>
+                        <DialogDescription>
+                            Are you sure you want to delete &apos;{node._name}&apos; ({node._path})? This action cannot be undone.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="flex items-center gap-2 py-2">
+                        <Checkbox
+                            id={`delete-all-${node._id}`}
+                            checked={deleteAllBranches}
+                            onCheckedChange={checked => setDeleteAllBranches(checked === true)}
+                        />
+                        <Label htmlFor={`delete-all-${node._id}`} className="font-normal">
+                            Delete from all branches
+                        </Label>
+                    </div>
+                    <DialogFooter>
+                        <DialogClose asChild>
+                            <Button>Cancel</Button>
+                        </DialogClose>
+                        <Button
+                            variant="destructive"
+                            onClick={handleDelete}
+                            disabled={deleteMutation.isPending}
+                        >
+                            Delete
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+};
+
+//
+// * CreateNodeDialog
+//
+
+type CreateNodeDialogProps = {
+    repoId: string;
+    branch: string;
+    parentPath: string;
+};
+
+const CreateNodeDialog = ({ repoId, branch, parentPath }: CreateNodeDialogProps): ReactElement => {
+    const [open, setOpen] = useState(false);
+    const [name, setName] = useState('');
+    const [nodeType, setNodeType] = useState('');
+    const [error, setError] = useState<string | undefined>();
+    const createMutation = useCreateNode();
+
+    const handleSubmit = () => {
+        if (name.trim() === '') {
+            setError('Name is required');
+            return;
+        }
+        if (name.includes('/')) {
+            setError('Name cannot contain slashes');
+            return;
+        }
+
+        createMutation.mutate(
+            {
+                repoId,
+                branch,
+                parentPath,
+                name,
+                nodeType: nodeType.trim() || undefined,
+            },
+            {
+                onSuccess: () => {
+                    toast.success(`Node '${name}' created`);
+                    setOpen(false);
+                    setName('');
+                    setNodeType('');
+                    setError(undefined);
+                },
+                onError: () => {
+                    toast.error(`Failed to create node '${name}'`);
+                },
+            },
+        );
+    };
+
+    const handleOpenChange = (nextOpen: boolean) => {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+            setName('');
+            setNodeType('');
+            setError(undefined);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogTrigger asChild>
+                <Button>
+                    <Plus className="size-4" />
+                    Create Node
+                </Button>
+            </DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Create Node</DialogTitle>
+                    <DialogDescription>
+                        Create a new child node in &apos;{parentPath}&apos;.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="grid gap-4 py-4">
+                    <div className="grid gap-2">
+                        <Label htmlFor="create-name">Name</Label>
+                        <Input
+                            id="create-name"
+                            value={name}
+                            onChange={e => {
+                                setName(e.target.value);
+                                setError(undefined);
+                            }}
+                            onKeyDown={e => {
+                                if (e.key === 'Enter') handleSubmit();
+                            }}
+                            placeholder="my-node"
+                        />
+                        {error != null && (
+                            <p className="text-destructive text-sm">{error}</p>
+                        )}
+                    </div>
+                    <div className="grid gap-2">
+                        <Label htmlFor="create-type">Node Type</Label>
+                        <Input
+                            id="create-type"
+                            value={nodeType}
+                            onChange={e => setNodeType(e.target.value)}
+                            placeholder="default"
+                        />
+                    </div>
+                </div>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button>Cancel</Button>
+                    </DialogClose>
+                    <Button
+                        variant="primary"
+                        onClick={handleSubmit}
+                        disabled={createMutation.isPending}
+                    >
+                        Create
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+//
 // * NodeBrowserPage
 //
 
@@ -167,6 +839,12 @@ const NodeBrowserPage = (): ReactElement => {
                 return rest;
             },
         });
+    };
+
+    const handleNodeDeleted = (deletedId: string) => {
+        if (nodeId === deletedId) {
+            closeNodeDetail();
+        }
     };
 
     const columns = [
@@ -206,30 +884,13 @@ const NodeBrowserPage = (): ReactElement => {
             meta: { className: 'w-20' },
             cell: info => (
                 <div className="flex items-center justify-end gap-1">
-                    <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={e => e.stopPropagation()}
-                            >
-                                <Ellipsis className="size-4 text-muted-foreground" />
-                            </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                            <DropdownMenuGroup>
-                                <DropdownMenuItem
-                                    onClick={e => {
-                                        e.stopPropagation();
-                                        openNodeDetail(info.row.original._id);
-                                    }}
-                                >
-                                    <Eye className="size-4" />
-                                    Preview
-                                </DropdownMenuItem>
-                            </DropdownMenuGroup>
-                        </DropdownMenuContent>
-                    </DropdownMenu>
+                    <RowActions
+                        node={info.row.original}
+                        repoId={repoId}
+                        branch={branch}
+                        onPreview={openNodeDetail}
+                        onDeleted={() => handleNodeDeleted(info.row.original._id)}
+                    />
                     <ChevronRight className={cn(
                         "size-4",
                         info.row.original.hasChildren
@@ -264,10 +925,7 @@ const NodeBrowserPage = (): ReactElement => {
             {/* Action toolbar */}
             <div className="flex items-center gap-2 px-4 py-2">
                 <div className="flex-1" />
-                <Button disabled>
-                    <Plus className="size-4" />
-                    Create Node
-                </Button>
+                <CreateNodeDialog repoId={repoId} branch={branch} parentPath={path} />
                 <Separator orientation="vertical" className="h-5" />
                 <div className="flex items-center gap-0.5">
                     <Button
@@ -427,6 +1085,7 @@ const NodeBrowserPage = (): ReactElement => {
                         repoId={repoId}
                         branch={branch}
                         onClose={closeNodeDetail}
+                        onNodeMutated={closeNodeDetail}
                     />
                 )}
             </div>

--- a/src/test/apis/nodes.test.ts
+++ b/src/test/apis/nodes.test.ts
@@ -9,12 +9,18 @@ vi.mock('/lib/xp/node', () => ({
     connect: vi.fn(),
 }));
 
+vi.mock('/lib/xp/repo', () => ({
+    get: vi.fn(),
+}));
+
 import { hasRole } from '/lib/xp/auth';
 import { connect } from '/lib/xp/node';
-import { get } from '../../main/resources/apis/nodes/nodes';
+import { get as getRepo } from '/lib/xp/repo';
+import { delete as deleteHandler, get, post, put } from '../../main/resources/apis/nodes/nodes';
 
 const mockedHasRole = vi.mocked(hasRole);
 const mockedConnect = vi.mocked(connect);
+const mockedGetRepo = vi.mocked(getRepo);
 
 function parseBody(response: { body?: string | object }) {
     return JSON.parse(response.body as string);
@@ -25,6 +31,12 @@ function createMockConnection(overrides: Record<string, unknown> = {}) {
         query: vi.fn().mockReturnValue({ total: 0, count: 0, hits: [] }),
         get: vi.fn().mockReturnValue([]),
         findChildren: vi.fn().mockReturnValue({ total: 0, count: 0, hits: [] }),
+        create: vi.fn().mockReturnValue({ _id: 'new-id', _name: 'new-node', _path: '/new-node' }),
+        push: vi.fn().mockReturnValue({ success: ['id-1'], failed: [], deleted: [] }),
+        move: vi.fn().mockReturnValue(true),
+        delete: vi.fn().mockReturnValue(['id-1']),
+        duplicate: vi.fn().mockReturnValue({ _id: 'dup-id', _name: 'node-copy', _path: '/node-copy' }),
+        exists: vi.fn().mockReturnValue(true),
         ...overrides,
     };
 }
@@ -316,5 +328,562 @@ describe('GET /nodes?key=', () => {
         } as unknown as Request);
         expect(response.status).toBe(500);
         expect(parseBody(response).code).toBe('INTERNAL_ERROR');
+    });
+});
+
+//
+// * POST — Create node
+//
+
+describe('POST /nodes (create)', () => {
+    test('creates a node with valid params', () => {
+        const createdNode = {
+            _id: 'new-id',
+            _name: 'my-node',
+            _path: '/my-node',
+            _nodeType: 'default',
+        };
+        const mockConn = createMockConnection({
+            create: vi.fn().mockReturnValue(createdNode),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        const response = post({
+            params: {},
+            body: JSON.stringify({
+                repoId: 'my-repo',
+                branch: 'master',
+                parentPath: '/',
+                name: 'my-node',
+            }),
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(response.status).toBe(201);
+        expect(body.data).toEqual(createdNode);
+        expect(mockConn.create).toHaveBeenCalledWith({
+            _parentPath: '/',
+            _name: 'my-node',
+            _nodeType: 'default',
+        });
+    });
+
+    test('creates a node with custom nodeType', () => {
+        const mockConn = createMockConnection();
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        post({
+            params: {},
+            body: JSON.stringify({
+                repoId: 'my-repo',
+                branch: 'master',
+                parentPath: '/content',
+                name: 'my-node',
+                nodeType: 'custom-type',
+            }),
+        } as unknown as Request);
+
+        expect(mockConn.create).toHaveBeenCalledWith({
+            _parentPath: '/content',
+            _name: 'my-node',
+            _nodeType: 'custom-type',
+        });
+    });
+
+    test('returns 400 when name is missing', () => {
+        const response = post({
+            params: {},
+            body: JSON.stringify({ repoId: 'my-repo', branch: 'master' }),
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 400 when repoId is missing', () => {
+        const response = post({
+            params: {},
+            body: JSON.stringify({ branch: 'master', name: 'test' }),
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 403 for non-admin users', () => {
+        mockedHasRole.mockReturnValue(false);
+        const response = post({
+            params: {},
+            body: JSON.stringify({ repoId: 'my-repo', branch: 'master', name: 'test' }),
+        } as unknown as Request);
+        expect(response.status).toBe(403);
+    });
+});
+
+//
+// * POST ?action=duplicate
+//
+
+describe('POST /nodes?action=duplicate', () => {
+    test('duplicates a node', () => {
+        const duplicated = {
+            _id: 'dup-id',
+            _name: 'my-node-copy',
+            _path: '/my-node-copy',
+            _nodeType: 'default',
+        };
+        const mockConn = createMockConnection({
+            duplicate: vi.fn().mockReturnValue(duplicated),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        const response = post({
+            params: { action: 'duplicate' },
+            body: JSON.stringify({
+                repoId: 'my-repo',
+                branch: 'master',
+                nodeId: 'id-1',
+            }),
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(response.status).toBe(201);
+        expect(body.data).toEqual(duplicated);
+        expect(mockConn.duplicate).toHaveBeenCalledWith({
+            nodeId: 'id-1',
+            name: undefined,
+            includeChildren: false,
+        });
+    });
+
+    test('duplicates a node with custom name', () => {
+        const mockConn = createMockConnection({
+            duplicate: vi.fn().mockReturnValue({ _id: 'dup-id', _name: 'custom-copy' }),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        post({
+            params: { action: 'duplicate' },
+            body: JSON.stringify({
+                repoId: 'my-repo',
+                branch: 'master',
+                nodeId: 'id-1',
+                name: 'custom-copy',
+                includeChildren: true,
+            }),
+        } as unknown as Request);
+
+        expect(mockConn.duplicate).toHaveBeenCalledWith({
+            nodeId: 'id-1',
+            name: 'custom-copy',
+            includeChildren: true,
+        });
+    });
+
+    test('returns 400 when nodeId is missing', () => {
+        const response = post({
+            params: { action: 'duplicate' },
+            body: JSON.stringify({ repoId: 'my-repo', branch: 'master' }),
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 403 for non-admin users', () => {
+        mockedHasRole.mockReturnValue(false);
+        const response = post({
+            params: { action: 'duplicate' },
+            body: JSON.stringify({ repoId: 'my-repo', branch: 'master', nodeId: 'id-1' }),
+        } as unknown as Request);
+        expect(response.status).toBe(403);
+    });
+});
+
+//
+// * POST ?action=push
+//
+
+describe('POST /nodes?action=push', () => {
+    test('pushes a node to target branch', () => {
+        const pushResult = { success: ['id-1'], failed: [], deleted: [] };
+        const mockConn = createMockConnection({
+            push: vi.fn().mockReturnValue(pushResult),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        const response = post({
+            params: { action: 'push' },
+            body: JSON.stringify({
+                repoId: 'my-repo',
+                branch: 'master',
+                key: 'id-1',
+                target: 'draft',
+            }),
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(response.status).toBe(200);
+        expect(body.data).toEqual(pushResult);
+        expect(mockConn.push).toHaveBeenCalledWith({
+            key: 'id-1',
+            target: 'draft',
+            includeChildren: false,
+            resolve: true,
+        });
+    });
+
+    test('returns 400 when target branch is missing', () => {
+        const response = post({
+            params: { action: 'push' },
+            body: JSON.stringify({ repoId: 'my-repo', branch: 'master', key: 'id-1' }),
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 400 when key is missing', () => {
+        const response = post({
+            params: { action: 'push' },
+            body: JSON.stringify({ repoId: 'my-repo', branch: 'master', target: 'draft' }),
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+});
+
+//
+// * PUT ?action=rename
+//
+
+describe('PUT /nodes?action=rename', () => {
+    test('renames a node', () => {
+        const mockConn = createMockConnection({
+            get: vi.fn().mockReturnValue({ _id: 'id-1', _path: '/content', _name: 'content' }),
+            move: vi.fn().mockReturnValue(true),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        const response = put({
+            params: { action: 'rename' },
+            body: JSON.stringify({
+                repoId: 'my-repo',
+                branch: 'master',
+                key: 'id-1',
+                newName: 'renamed-content',
+            }),
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(response.status).toBe(200);
+        expect(body.data.success).toBe(true);
+        expect(mockConn.move).toHaveBeenCalledWith({
+            source: 'id-1',
+            target: 'renamed-content',
+        });
+    });
+
+    test('returns 400 when newName is missing', () => {
+        const response = put({
+            params: { action: 'rename' },
+            body: JSON.stringify({ repoId: 'my-repo', branch: 'master', key: 'id-1' }),
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 403 for root node', () => {
+        const mockConn = createMockConnection({
+            get: vi.fn().mockReturnValue({ _id: 'root-id', _path: '/', _name: '' }),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        const response = put({
+            params: { action: 'rename' },
+            body: JSON.stringify({
+                repoId: 'my-repo',
+                branch: 'master',
+                key: 'root-id',
+                newName: 'new-root',
+            }),
+        } as unknown as Request);
+
+        expect(response.status).toBe(403);
+        expect(parseBody(response).code).toBe('PROTECTED_NODE');
+    });
+
+    test('returns 404 when node not found', () => {
+        const mockConn = createMockConnection({
+            get: vi.fn().mockReturnValue(null),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        const response = put({
+            params: { action: 'rename' },
+            body: JSON.stringify({
+                repoId: 'my-repo',
+                branch: 'master',
+                key: 'nonexistent',
+                newName: 'new-name',
+            }),
+        } as unknown as Request);
+
+        expect(response.status).toBe(404);
+        expect(parseBody(response).code).toBe('NOT_FOUND');
+    });
+
+    test('returns 403 for non-admin users', () => {
+        mockedHasRole.mockReturnValue(false);
+        const response = put({
+            params: { action: 'rename' },
+            body: JSON.stringify({
+                repoId: 'my-repo',
+                branch: 'master',
+                key: 'id-1',
+                newName: 'new-name',
+            }),
+        } as unknown as Request);
+        expect(response.status).toBe(403);
+    });
+});
+
+//
+// * PUT ?action=move
+//
+
+describe('PUT /nodes?action=move', () => {
+    test('moves a node to target path', () => {
+        const mockConn = createMockConnection({
+            get: vi.fn()
+                .mockReturnValueOnce({ _id: 'id-1', _path: '/content', _name: 'content' })
+                .mockReturnValueOnce({ _id: 'target-id', _path: '/archive', _name: 'archive' }),
+            move: vi.fn().mockReturnValue(true),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        const response = put({
+            params: { action: 'move' },
+            body: JSON.stringify({
+                repoId: 'my-repo',
+                branch: 'master',
+                key: 'id-1',
+                targetPath: '/archive',
+            }),
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(response.status).toBe(200);
+        expect(body.data.success).toBe(true);
+        expect(mockConn.move).toHaveBeenCalledWith({
+            source: 'id-1',
+            target: '/archive',
+        });
+    });
+
+    test('returns 400 when targetPath is missing', () => {
+        const response = put({
+            params: { action: 'move' },
+            body: JSON.stringify({ repoId: 'my-repo', branch: 'master', key: 'id-1' }),
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 404 when target path does not exist', () => {
+        const mockConn = createMockConnection({
+            get: vi.fn()
+                .mockReturnValueOnce({ _id: 'id-1', _path: '/content', _name: 'content' })
+                .mockReturnValueOnce(null),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        const response = put({
+            params: { action: 'move' },
+            body: JSON.stringify({
+                repoId: 'my-repo',
+                branch: 'master',
+                key: 'id-1',
+                targetPath: '/nonexistent',
+            }),
+        } as unknown as Request);
+
+        expect(response.status).toBe(404);
+    });
+
+    test('returns 403 for root node', () => {
+        const mockConn = createMockConnection({
+            get: vi.fn().mockReturnValue({ _id: 'root-id', _path: '/', _name: '' }),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        const response = put({
+            params: { action: 'move' },
+            body: JSON.stringify({
+                repoId: 'my-repo',
+                branch: 'master',
+                key: 'root-id',
+                targetPath: '/somewhere',
+            }),
+        } as unknown as Request);
+
+        expect(response.status).toBe(403);
+        expect(parseBody(response).code).toBe('PROTECTED_NODE');
+    });
+});
+
+//
+// * PUT — invalid action
+//
+
+describe('PUT /nodes (no action)', () => {
+    test('returns 400 when action is missing', () => {
+        const response = put({
+            params: {},
+            body: JSON.stringify({ repoId: 'my-repo', branch: 'master', key: 'id-1' }),
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+});
+
+//
+// * DELETE
+//
+
+describe('DELETE /nodes', () => {
+    test('deletes a node', () => {
+        const mockConn = createMockConnection({
+            get: vi.fn().mockReturnValue({ _id: 'id-1', _path: '/content', _name: 'content' }),
+            delete: vi.fn().mockReturnValue(['id-1']),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        const response = deleteHandler({
+            params: { repoId: 'my-repo', branch: 'master', key: 'id-1' },
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(response.status).toBe(200);
+        expect(body.data.key).toBe('id-1');
+        expect(body.data.deleted).toBe(true);
+        expect(mockConn.delete).toHaveBeenCalledWith('id-1');
+    });
+
+    test('returns 400 when key is missing', () => {
+        const response = deleteHandler({
+            params: { repoId: 'my-repo', branch: 'master' },
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 403 for root node', () => {
+        const mockConn = createMockConnection({
+            get: vi.fn().mockReturnValue({ _id: 'root-id', _path: '/', _name: '' }),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        const response = deleteHandler({
+            params: { repoId: 'my-repo', branch: 'master', key: 'root-id' },
+        } as unknown as Request);
+
+        expect(response.status).toBe(403);
+        expect(parseBody(response).code).toBe('PROTECTED_NODE');
+    });
+
+    test('returns 404 when node not found', () => {
+        const mockConn = createMockConnection({
+            get: vi.fn().mockReturnValue(null),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+
+        const response = deleteHandler({
+            params: { repoId: 'my-repo', branch: 'master', key: 'nonexistent' },
+        } as unknown as Request);
+
+        expect(response.status).toBe(404);
+        expect(parseBody(response).code).toBe('NOT_FOUND');
+    });
+
+    test('returns 403 for non-admin users', () => {
+        mockedHasRole.mockReturnValue(false);
+        const response = deleteHandler({
+            params: { repoId: 'my-repo', branch: 'master', key: 'id-1' },
+        } as unknown as Request);
+        expect(response.status).toBe(403);
+    });
+
+    test('returns 500 when delete fails', () => {
+        mockedConnect.mockImplementation(() => {
+            throw new Error('Connection failed');
+        });
+
+        const response = deleteHandler({
+            params: { repoId: 'my-repo', branch: 'master', key: 'id-1' },
+        } as unknown as Request);
+        expect(response.status).toBe(500);
+        expect(parseBody(response).code).toBe('INTERNAL_ERROR');
+    });
+
+    test('deletes from all branches when allBranches=true', () => {
+        const mockConn = createMockConnection({
+            get: vi.fn().mockReturnValue({ _id: 'id-1', _path: '/content', _name: 'content' }),
+            delete: vi.fn().mockReturnValue(['id-1']),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+        mockedGetRepo.mockReturnValue({ id: 'my-repo', branches: ['master', 'draft'] } as never);
+
+        const response = deleteHandler({
+            params: { repoId: 'my-repo', branch: 'master', key: 'id-1', allBranches: 'true' },
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(response.status).toBe(200);
+        expect(body.data.deleted).toBe(true);
+        expect(body.data.branches.deleted).toEqual(['master', 'draft']);
+        expect(mockedConnect).toHaveBeenCalledTimes(3);
+    });
+
+    test('returns 404 when repo not found for allBranches delete', () => {
+        const mockConn = createMockConnection({
+            get: vi.fn().mockReturnValue({ _id: 'id-1', _path: '/content', _name: 'content' }),
+        });
+        mockedConnect.mockReturnValue(mockConn as never);
+        mockedGetRepo.mockReturnValue(null as never);
+
+        const response = deleteHandler({
+            params: { repoId: 'missing-repo', branch: 'master', key: 'id-1', allBranches: 'true' },
+        } as unknown as Request);
+
+        expect(response.status).toBe(404);
+        expect(parseBody(response).code).toBe('NOT_FOUND');
+    });
+
+    test('skips branches where node does not exist', () => {
+        let callCount = 0;
+        mockedConnect.mockImplementation(() => {
+            callCount++;
+            if (callCount <= 1) {
+                return createMockConnection({
+                    get: vi.fn().mockReturnValue({ _id: 'id-1', _path: '/content', _name: 'content' }),
+                    delete: vi.fn().mockReturnValue(['id-1']),
+                }) as never;
+            }
+            if (callCount === 2) {
+                return createMockConnection({
+                    get: vi.fn().mockReturnValue({ _id: 'id-1', _path: '/content', _name: 'content' }),
+                    delete: vi.fn().mockReturnValue(['id-1']),
+                }) as never;
+            }
+            return createMockConnection({
+                get: vi.fn().mockReturnValue(null),
+            }) as never;
+        });
+        mockedGetRepo.mockReturnValue({ id: 'my-repo', branches: ['master', 'draft'] } as never);
+
+        const response = deleteHandler({
+            params: { repoId: 'my-repo', branch: 'master', key: 'id-1', allBranches: 'true' },
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(response.status).toBe(200);
+        expect(body.data.branches.deleted).toContain('master');
     });
 });


### PR DESCRIPTION
## Changes

- Added `POST`, `PUT`, `DELETE` handlers to the nodes API for create, rename, move, duplicate, push, and delete
- Added mutation functions and React Query hooks for all six operations with cache invalidation
- Implemented `RowActions` dropdown in the node browser with dialogs for all actions
- Added `PanelActions` dropdown to the `NodeDetailPanel` header with the same actions
- Added `CreateNodeDialog` to the toolbar and "delete from all branches" checkbox to delete confirmation
- Fixed React portal event bubbling in `DialogContent` and `AlertDialogContent` to prevent row click handler from firing during dialog interactions
- Added backend tests for all new API endpoints including `allBranches` delete behavior

Closes #10

<sub>*Drafted with AI assistance*</sub>