### PR TITLE
improvement: switch server-side engine to GraalJS and target ES2023 #66

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ pnpm test           # vitest only
 **Build pipeline:** Two parallel pipelines compile TypeScript into `build/resources/main/`:
 
 - **Client-side (Vite):** `src/main/resources/assets/` — React app (`js` target) and Tailwind 4 CSS (`css` target), controlled by `BUILD_TARGET` env var
-- **Server-side (esbuild):** `src/main/resources/**/*.ts` (excluding `assets/`, `lib/`, `types/`) — CJS ES2015 for XP's Nashorn engine. Auto-discovers `.ts` entry points. XP imports (`/lib/xp/*`, `/lib/mustache`) are externalized.
+- **Server-side (esbuild):** `src/main/resources/**/*.ts` (excluding `assets/`, `lib/`, `types/`) — CJS ES2023 for XP's GraalJS engine. Auto-discovers `.ts` entry points. XP imports (`/lib/xp/*`, `/lib/mustache`) are externalized.
 - Uses `@enonic-types/*@8.0.0-A2` for type-checking (XP 8 alpha types)
 
 **Admin tool entry:**

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ app {
     vendorName = "${vendorName}"
     vendorUrl = "${vendorUrl}"
     systemVersion = "${xpVersion}"
+    scriptEngine = "GraalJS"
 }
 
 dependencies {

--- a/esbuild.server.js
+++ b/esbuild.server.js
@@ -17,8 +17,7 @@ await build({
     outbase: SRC,
     bundle: true,
     format: 'cjs',
-    target: 'es2015',
-    supported: { 'for-of': false }, // ? Nashorn doesn't handle `let` bindings in `for...of` correctly
+    target: 'es2023',
     platform: 'neutral',
     mainFields: ['module', 'main'],
     external: [

--- a/src/main/resources/apis/branches/branches.ts
+++ b/src/main/resources/apis/branches/branches.ts
@@ -25,10 +25,7 @@ export function get(req: Request): Response {
             return errorResponse(404, `Repository '${repoId}' not found`, 'NOT_FOUND');
         }
 
-        const branches: BranchDto[] = [];
-        for (let i = 0; i < repo.branches.length; i++) {
-            branches.push({ id: repo.branches[i] });
-        }
+        const branches: BranchDto[] = repo.branches.map(id => ({ id }));
 
         return jsonResponse(branches);
     } catch (_e) {
@@ -83,7 +80,7 @@ function delete_(req: Request): Response {
         return errorResponse(400, 'Branch ID is required', 'VALIDATION_ERROR');
     }
 
-    if (PROTECTED_BRANCHES.indexOf(branchId) !== -1) {
+    if (PROTECTED_BRANCHES.includes(branchId)) {
         return errorResponse(403, `Branch '${branchId}' is protected and cannot be deleted`, 'PROTECTED_BRANCH');
     }
 

--- a/src/main/resources/apis/nodes/nodes.ts
+++ b/src/main/resources/apis/nodes/nodes.ts
@@ -54,10 +54,7 @@ function getNodeList(req: Request, repoId: string, branch: string): Response {
             return jsonResponse({ nodes: [], total: queryResult.total } satisfies NodesResult);
         }
 
-        const ids = [];
-        for (let i = 0; i < queryResult.hits.length; i++) {
-            ids.push(queryResult.hits[i].id);
-        }
+        const ids = queryResult.hits.map(hit => hit.id);
 
         const rawNodes = repo.get(ids);
         if (rawNodes == null) {
@@ -66,24 +63,22 @@ function getNodeList(req: Request, repoId: string, branch: string): Response {
 
         const nodesArray = Array.isArray(rawNodes) ? rawNodes : [rawNodes];
 
-        const nodes: NodeDto[] = [];
-        for (let i = 0; i < nodesArray.length; i++) {
-            const node = nodesArray[i];
+        const nodes: NodeDto[] = nodesArray.map(node => {
             const children = repo.findChildren({
                 parentKey: node._id,
                 countOnly: true,
                 count: 0,
             });
 
-            nodes.push({
+            return {
                 _id: node._id,
                 _name: node._name,
                 _path: node._path,
                 hasChildren: children.total > 0,
                 _nodeType: node._nodeType,
                 _ts: node._ts,
-            });
-        }
+            };
+        });
 
         return jsonResponse({ nodes, total: queryResult.total } satisfies NodesResult);
     } catch (_e) {
@@ -366,8 +361,7 @@ function delete_(req: Request): Response {
 
             const deleted: string[] = [];
             const failed: string[] = [];
-            for (let i = 0; i < repoInfo.branches.length; i++) {
-                const branchId = repoInfo.branches[i];
+            for (const branchId of repoInfo.branches) {
                 try {
                     const branchRepo = connect({ repoId, branch: branchId });
                     const branchNode = branchRepo.get(key);

--- a/src/main/resources/apis/repositories/repositories.ts
+++ b/src/main/resources/apis/repositories/repositories.ts
@@ -56,7 +56,7 @@ function delete_(req: Request): Response {
         return errorResponse(400, 'Repository ID is required', 'VALIDATION_ERROR');
     }
 
-    if (PROTECTED_REPOS.indexOf(id) !== -1) {
+    if (PROTECTED_REPOS.includes(id)) {
         return errorResponse(403, `Repository '${id}' is protected and cannot be deleted`, 'PROTECTED_REPO');
     }
 

--- a/src/main/resources/apis/search/search.ts
+++ b/src/main/resources/apis/search/search.ts
@@ -46,25 +46,21 @@ function querySingleRepo(
     const hits: SearchHitDto[] = [];
 
     if (queryResult.count > 0) {
-        const ids: string[] = [];
-        for (let i = 0; i < queryResult.hits.length; i++) {
-            ids.push(queryResult.hits[i].id);
-        }
+        const ids = queryResult.hits.map(hit => hit.id);
 
         const rawNodes = repo.get(ids);
         const nodesArray = rawNodes == null ? [] : Array.isArray(rawNodes) ? rawNodes : [rawNodes];
 
-        for (let i = 0; i < queryResult.hits.length; i++) {
-            const hit = queryResult.hits[i];
+        for (const [i, hit] of queryResult.hits.entries()) {
             const node = nodesArray[i];
             hits.push({
                 _id: hit.id,
                 _score: hit.score,
                 _repoId: repoId,
                 _branch: branch,
-                _name: node != null ? node._name : undefined,
-                _path: node != null ? node._path : undefined,
-                _nodeType: node != null ? node._nodeType : undefined,
+                _name: node?._name,
+                _path: node?._path,
+                _nodeType: node?._nodeType,
             });
         }
     }
@@ -87,12 +83,11 @@ function queryAllRepos(
     const repos = list();
     const sources: Array<{ repoId: string; branch: string; principals: PrincipalKey[] }> = [];
 
-    for (let i = 0; i < repos.length; i++) {
-        const repo = repos[i];
-        for (let j = 0; j < repo.branches.length; j++) {
+    for (const repo of repos) {
+        for (const branch of repo.branches) {
             sources.push({
                 repoId: repo.id,
-                branch: repo.branches[j],
+                branch,
                 principals: ['role:system.admin'],
             });
         }
@@ -107,8 +102,7 @@ function queryAllRepos(
 
     const hits: SearchHitDto[] = [];
 
-    for (let i = 0; i < queryResult.hits.length; i++) {
-        const hit = queryResult.hits[i];
+    for (const hit of queryResult.hits) {
         hits.push({
             _id: hit.id,
             _score: hit.score,
@@ -119,8 +113,7 @@ function queryAllRepos(
 
     // Enrich hits with node metadata by grouping by repo+branch
     const groups: Record<string, { repoId: string; branch: string; indices: number[]; ids: string[] }> = {};
-    for (let i = 0; i < hits.length; i++) {
-        const h = hits[i];
+    for (const [i, h] of hits.entries()) {
         const groupKey = `${h._repoId}::${h._branch}`;
         if (groups[groupKey] == null) {
             groups[groupKey] = { repoId: h._repoId, branch: h._branch, indices: [], ids: [] };
@@ -129,16 +122,13 @@ function queryAllRepos(
         groups[groupKey].ids.push(h._id);
     }
 
-    const groupKeys = Object.keys(groups);
-    for (let i = 0; i < groupKeys.length; i++) {
-        const group = groups[groupKeys[i]];
+    for (const group of Object.values(groups)) {
         try {
             const conn = connect({ repoId: group.repoId, branch: group.branch });
             const rawNodes = conn.get(group.ids);
             const nodesArray = rawNodes == null ? [] : Array.isArray(rawNodes) ? rawNodes : [rawNodes];
 
-            for (let j = 0; j < group.indices.length; j++) {
-                const idx = group.indices[j];
+            for (const [j, idx] of group.indices.entries()) {
                 const node = nodesArray[j];
                 if (node != null) {
                     hits[idx]._name = node._name;
@@ -191,7 +181,7 @@ export function post(req: Request): Response {
     } catch (e) {
         const message = e instanceof Error ? e.message : String(e);
 
-        if (message.indexOf('ParseException') !== -1 || message.indexOf('parse') !== -1) {
+        if (message.includes('ParseException') || message.includes('parse')) {
             return errorResponse(400, `Invalid NoQL syntax: ${message}`, 'QUERY_ERROR');
         }
 

--- a/src/main/resources/lib/jwt.ts
+++ b/src/main/resources/lib/jwt.ts
@@ -28,8 +28,7 @@ export function getJwtConfig(): JwtConfig | undefined {
     const keyId = app.config['managementApi.jwt.keyId'];
     const privateKeyPath = app.config['managementApi.jwt.privateKeyPath'];
     const expirationSeconds = parseInt(app.config['managementApi.jwt.expirationSeconds'] ?? '', 10);
-    // biome-ignore lint/suspicious/noGlobalIsNan: Number.isNaN is not available in Nashorn
-    const expiration = isNaN(expirationSeconds) ? DEFAULT_EXPIRATION_SECONDS : expirationSeconds;
+    const expiration = Number.isNaN(expirationSeconds) ? DEFAULT_EXPIRATION_SECONDS : expirationSeconds;
 
     if (privateKeyPath == null) {
         throw new Error(

--- a/src/main/resources/tsconfig.json
+++ b/src/main/resources/tsconfig.json
@@ -1,13 +1,13 @@
 {
     "compilerOptions": {
-        "target": "ES2015",
-        "module": "CommonJS",
-        "moduleResolution": "node",
-        "lib": ["ES2015"],
+        "target": "ES2023",
+        "module": "ES2022",
+        "moduleResolution": "bundler",
+        "lib": ["ES2023"],
         "noEmit": true,
         "strict": true,
         "skipLibCheck": true,
-        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
         "forceConsistentCasingInFileNames": true,
         "isolatedModules": true,
         "paths": {


### PR DESCRIPTION
Switch server-side JS engine from Nashorn to GraalJS. Set `scriptEngine = "GraalJS"` in `build.gradle`, bump esbuild target to ES2023, update server tsconfig to ES2023/ES2022/bundler. Modernize all server-side TS: `for...of`/`.map()` instead of index loops, `.includes()` instead of `.indexOf()`, `Number.isNaN()` instead of global `isNaN()`.

Closes #66

<sub>*Drafted with AI assistance*</sub>
