### PR TITLE
feat: add dump and export upload/download #17

### DIFF
--- a/src/main/kotlin/com/enonic/app/datakit/DumpManager.kt
+++ b/src/main/kotlin/com/enonic/app/datakit/DumpManager.kt
@@ -1,8 +1,11 @@
 package com.enonic.app.datakit
 
 import com.enonic.xp.home.HomeDir
+import com.google.common.io.ByteSource
+import com.google.common.io.Files as GuavaFiles
 import org.osgi.service.component.annotations.Component
 import java.io.IOException
+import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Properties
@@ -58,6 +61,60 @@ class DumpManager {
         } catch (e: IOException) {
             throw RuntimeException("Failed to delete dump '$name': ${e.message}", e)
         }
+    }
+
+    fun download(name: String?): ByteSource? {
+        if (name.isNullOrEmpty()) return null
+
+        val dumpDir = dumpDirectory()
+        val target = dumpDir.resolve(name).normalize()
+        if (!target.startsWith(dumpDir)) return null
+
+        val archive = dumpDir.resolve("$name.zip").normalize()
+        if (!archive.startsWith(dumpDir)) return null
+
+        if (Files.isRegularFile(archive)) {
+            return GuavaFiles.asByteSource(archive.toFile())
+        }
+
+        if (Files.isDirectory(target) && isValidDumpDirectory(target)) {
+            return target.zipToByteSource()
+        }
+
+        return null
+    }
+
+    fun upload(name: String?, data: InputStream?): Boolean {
+        if (name.isNullOrEmpty() || data == null) return false
+
+        val dumpDir = dumpDirectory()
+        val target = dumpDir.resolve("$name.zip").normalize()
+        if (!target.startsWith(dumpDir)) return false
+
+        if (Files.exists(target) || Files.isDirectory(dumpDir.resolve(name).normalize())) return false
+
+        val tempFile = dumpDir.resolve(".$name.zip.tmp").normalize()
+        if (!tempFile.startsWith(dumpDir)) return false
+
+        try {
+            if (!Files.isDirectory(dumpDir)) {
+                Files.createDirectories(dumpDir)
+            }
+            try {
+                saveStream(tempFile, data)
+                Files.move(tempFile, target)
+            } finally {
+                Files.deleteIfExists(tempFile)
+            }
+            return true
+        } catch (e: IOException) {
+            throw RuntimeException("Failed to upload dump '$name': ${e.message}", e)
+        }
+    }
+
+    private fun isValidDumpDirectory(dir: Path): Boolean {
+        return Files.isRegularFile(dir.resolve("dump.json")) ||
+            Files.isRegularFile(dir.resolve("export.properties"))
     }
 
     private fun buildEntryJson(entry: Path): String? {

--- a/src/main/kotlin/com/enonic/app/datakit/ExportManager.kt
+++ b/src/main/kotlin/com/enonic/app/datakit/ExportManager.kt
@@ -1,8 +1,11 @@
 package com.enonic.app.datakit
 
 import com.enonic.xp.home.HomeDir
+import com.google.common.io.ByteSource
+import com.google.common.io.Files as GuavaFiles
 import org.osgi.service.component.annotations.Component
 import java.io.IOException
+import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.deleteIfExists
@@ -76,6 +79,55 @@ class ExportManager {
             }
         } catch (_: IOException) {
             // ? Metadata is non-critical; export already succeeded
+        }
+    }
+
+    fun download(name: String?): ByteSource? {
+        if (name.isNullOrEmpty()) return null
+
+        val exportDir = exportDirectory()
+        val target = exportDir.resolve(name).normalize()
+        if (!target.startsWith(exportDir)) return null
+
+        val archive = exportDir.resolve("$name.zip").normalize()
+        if (!archive.startsWith(exportDir)) return null
+
+        if (Files.isRegularFile(archive)) {
+            return GuavaFiles.asByteSource(archive.toFile())
+        }
+
+        if (Files.isDirectory(target)) {
+            return target.zipToByteSource()
+        }
+
+        return null
+    }
+
+    fun upload(name: String?, data: InputStream?): Boolean {
+        if (name.isNullOrEmpty() || data == null) return false
+
+        val exportDir = exportDirectory()
+        val target = exportDir.resolve("$name.zip").normalize()
+        if (!target.startsWith(exportDir)) return false
+
+        if (Files.exists(target) || Files.isDirectory(exportDir.resolve(name).normalize())) return false
+
+        val tempFile = exportDir.resolve(".$name.zip.tmp").normalize()
+        if (!tempFile.startsWith(exportDir)) return false
+
+        try {
+            if (!Files.isDirectory(exportDir)) {
+                Files.createDirectories(exportDir)
+            }
+            try {
+                saveStream(tempFile, data)
+                Files.move(tempFile, target)
+            } finally {
+                Files.deleteIfExists(tempFile)
+            }
+            return true
+        } catch (e: IOException) {
+            throw RuntimeException("Failed to upload export '$name': ${e.message}", e)
         }
     }
 

--- a/src/main/kotlin/com/enonic/app/datakit/Support.kt
+++ b/src/main/kotlin/com/enonic/app/datakit/Support.kt
@@ -1,8 +1,13 @@
 package com.enonic.app.datakit
 
+import com.google.common.io.ByteSource
+import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 internal fun Path.directorySize(): Long {
     var size = 0L
@@ -45,6 +50,29 @@ internal fun Path.lastModifiedOrEmpty(): String =
     } catch (_: IOException) {
         ""
     }
+
+internal fun Path.zipToByteSource(): ByteSource {
+    val buffer = ByteArrayOutputStream()
+
+    ZipOutputStream(buffer).use { zos ->
+        Files.walk(this).use { paths ->
+            for (path in paths) {
+                if (Files.isRegularFile(path)) {
+                    val entryName = this.relativize(path).toString()
+                    zos.putNextEntry(ZipEntry(entryName))
+                    Files.newInputStream(path).use { input -> input.copyTo(zos) }
+                    zos.closeEntry()
+                }
+            }
+        }
+    }
+
+    return ByteSource.wrap(buffer.toByteArray())
+}
+
+internal fun saveStream(target: Path, source: InputStream) {
+    Files.copy(source, target)
+}
 
 internal fun jsonString(value: String?): String {
     if (value.isNullOrEmpty()) return "\"\""

--- a/src/main/resources/apis/dumps/dumps.ts
+++ b/src/main/resources/apis/dumps/dumps.ts
@@ -1,16 +1,50 @@
 import type { Request, Response } from '@enonic-types/core';
+import { getMultipartItem, getMultipartStream } from '/lib/xp/portal';
 import { errorResponse, getParam, jsonResponse, requireAdmin } from '../../lib/api';
 import {
     createDump,
     deleteDump,
+    downloadDump,
     listDumps,
     loadDump,
     upgradeDump,
+    uploadDump,
 } from '../../lib/dumps';
 
-export function get(_req: Request): Response {
+const VALID_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{1,98}[A-Za-z0-9]$/;
+
+function safeFilename(name: string): string {
+    return name.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+export function get(req: Request): Response {
     const forbidden = requireAdmin();
     if (forbidden != null) return forbidden;
+
+    const action = getParam(req, 'action');
+
+    if (action === 'download') {
+        const name = getParam(req, 'name');
+        if (name == null) {
+            return errorResponse(400, 'name is required', 'VALIDATION_ERROR');
+        }
+        try {
+            const stream = downloadDump(name);
+            if (stream == null) {
+                return errorResponse(404, `Dump '${name}' not found`, 'NOT_FOUND');
+            }
+            return {
+                status: 200,
+                contentType: 'application/zip',
+                body: stream,
+                headers: {
+                    'Content-Disposition': `attachment; filename="${safeFilename(name)}.zip"`,
+                },
+            };
+        } catch (e) {
+            return errorResponse(500, String(e), 'INTERNAL_ERROR');
+        }
+    }
 
     try {
         const dumps = listDumps();
@@ -24,8 +58,27 @@ export function post(req: Request): Response {
     const forbidden = requireAdmin();
     if (forbidden != null) return forbidden;
 
-    const authHeader = req.headers?.Authorization;
     const action = getParam(req, 'action');
+
+    if (action === 'upload') {
+        try {
+            const item = getMultipartItem('file');
+            if (item == null) return errorResponse(400, 'file is required', 'VALIDATION_ERROR');
+            const stream = getMultipartStream('file');
+            if (stream == null) return errorResponse(400, 'file stream is empty', 'VALIDATION_ERROR');
+            const name = item.fileName.endsWith('.zip') ? item.fileName.slice(0, -4) : item.fileName;
+            if (!VALID_NAME_PATTERN.test(name)) {
+                return errorResponse(400, 'filename contains invalid characters', 'VALIDATION_ERROR');
+            }
+            const success = uploadDump(name, stream);
+            if (!success) return errorResponse(409, `Dump '${name}' already exists`, 'CONFLICT');
+            return jsonResponse({ success: true, name });
+        } catch (e) {
+            return errorResponse(500, String(e), 'INTERNAL_ERROR');
+        }
+    }
+
+    const authHeader = req.headers?.Authorization;
     const body = req.body != null ? JSON.parse(req.body as string) : {};
 
     try {

--- a/src/main/resources/apis/exports/exports.ts
+++ b/src/main/resources/apis/exports/exports.ts
@@ -1,17 +1,49 @@
 import type { Request, Response } from '@enonic-types/core';
+import { getMultipartItem, getMultipartStream } from '/lib/xp/portal';
 import { errorResponse, getParam, jsonResponse, requireAdmin } from '../../lib/api';
 import {
     createExport,
     deleteExport,
+    downloadExport,
     importExport,
     listExports,
+    uploadExport,
 } from '../../lib/exports';
 
 const VALID_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{1,98}[A-Za-z0-9]$/;
 
-export function get(_req: Request): Response {
+function safeFilename(name: string): string {
+    return name.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+export function get(req: Request): Response {
     const forbidden = requireAdmin();
     if (forbidden != null) return forbidden;
+
+    const action = getParam(req, 'action');
+
+    if (action === 'download') {
+        const name = getParam(req, 'name');
+        if (name == null) {
+            return errorResponse(400, 'name is required', 'VALIDATION_ERROR');
+        }
+        try {
+            const stream = downloadExport(name);
+            if (stream == null) {
+                return errorResponse(404, `Export '${name}' not found`, 'NOT_FOUND');
+            }
+            return {
+                status: 200,
+                contentType: 'application/zip',
+                body: stream,
+                headers: {
+                    'Content-Disposition': `attachment; filename="${safeFilename(name)}.zip"`,
+                },
+            };
+        } catch (e) {
+            return errorResponse(500, String(e), 'INTERNAL_ERROR');
+        }
+    }
 
     try {
         const entries = listExports();
@@ -26,6 +58,25 @@ export function post(req: Request): Response {
     if (forbidden != null) return forbidden;
 
     const action = getParam(req, 'action');
+
+    if (action === 'upload') {
+        try {
+            const item = getMultipartItem('file');
+            if (item == null) return errorResponse(400, 'file is required', 'VALIDATION_ERROR');
+            const stream = getMultipartStream('file');
+            if (stream == null) return errorResponse(400, 'file stream is empty', 'VALIDATION_ERROR');
+            const name = item.fileName.endsWith('.zip') ? item.fileName.slice(0, -4) : item.fileName;
+            if (!VALID_NAME_PATTERN.test(name)) {
+                return errorResponse(400, 'filename contains invalid characters', 'VALIDATION_ERROR');
+            }
+            const success = uploadExport(name, stream);
+            if (!success) return errorResponse(409, `Export '${name}' already exists`, 'CONFLICT');
+            return jsonResponse({ success: true, name });
+        } catch (e) {
+            return errorResponse(500, String(e), 'INTERNAL_ERROR');
+        }
+    }
+
     const body = req.body != null ? JSON.parse(req.body as string) : {};
 
     try {

--- a/src/main/resources/assets/js/lib/api/client.ts
+++ b/src/main/resources/assets/js/lib/api/client.ts
@@ -8,7 +8,7 @@ type ApiFetchOptions = {
     params?: Record<string, string>;
 };
 
-function buildUrl(apiUrl: string, params?: Record<string, string>): string {
+export function buildUrl(apiUrl: string, params?: Record<string, string>): string {
     const url = new URL(apiUrl, window.location.origin);
 
     if (params != null) {
@@ -48,4 +48,52 @@ export async function apiFetch<T>(apiUrl: string, options: ApiFetchOptions = {})
 
     const envelope: ApiResponse<T> = await response.json();
     return envelope.data;
+}
+
+export type UploadOptions = {
+    file: File;
+    params?: Record<string, string>;
+    onProgress?: (percent: number) => void;
+};
+
+export async function apiUpload(apiUrl: string, options: UploadOptions): Promise<void> {
+    const { file, params, onProgress } = options;
+    const url = buildUrl(apiUrl, params);
+
+    return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        const formData = new FormData();
+        formData.append('file', file);
+
+        xhr.upload.addEventListener('progress', (e) => {
+            if (e.lengthComputable && onProgress != null) {
+                onProgress(Math.round((e.loaded / e.total) * 100));
+            }
+        });
+
+        xhr.addEventListener('load', () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                resolve();
+            } else {
+                try {
+                    const error: ApiError = JSON.parse(xhr.responseText);
+                    reject(error);
+                } catch {
+                    reject({ status: xhr.status, message: xhr.statusText });
+                }
+            }
+        });
+
+        xhr.addEventListener('error', () => {
+            reject({ status: 0, message: 'Network error' });
+        });
+
+        xhr.addEventListener('timeout', () => {
+            reject({ status: 0, message: 'Upload timed out' });
+        });
+
+        xhr.open('POST', url);
+        xhr.setRequestHeader('Accept', 'application/json');
+        xhr.send(formData);
+    });
 }

--- a/src/main/resources/assets/js/lib/api/dumps.ts
+++ b/src/main/resources/assets/js/lib/api/dumps.ts
@@ -1,6 +1,6 @@
 import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getConfig } from '../config';
-import { apiFetch } from './client';
+import { apiFetch, apiUpload, buildUrl } from './client';
 
 export type Dump = {
     name: string;
@@ -67,6 +67,16 @@ export function upgradeDump(name: string): Promise<TaskIdResult> {
     });
 }
 
+export function getDumpDownloadUrl(name: string): string {
+    const { apiUris } = getConfig();
+    return buildUrl(apiUris.dumps, { action: 'download', name });
+}
+
+export function uploadDump(file: File, onProgress?: (percent: number) => void): Promise<void> {
+    const { apiUris } = getConfig();
+    return apiUpload(apiUris.dumps, { file, params: { action: 'upload' }, onProgress });
+}
+
 export function dumpsQueryOptions() {
     return queryOptions({
         queryKey: ['dumps'],
@@ -99,5 +109,20 @@ export function useDeleteDump() {
 export function useUpgradeDump() {
     return useMutation({
         mutationFn: upgradeDump,
+    });
+}
+
+type UploadDumpParams = {
+    file: File;
+    onProgress?: (percent: number) => void;
+};
+
+export function useUploadDump() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ file, onProgress }: UploadDumpParams) => uploadDump(file, onProgress),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['dumps'] });
+        },
     });
 }

--- a/src/main/resources/assets/js/lib/api/exports.ts
+++ b/src/main/resources/assets/js/lib/api/exports.ts
@@ -1,6 +1,6 @@
 import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getConfig } from '../config';
-import { apiFetch } from './client';
+import { apiFetch, apiUpload, buildUrl } from './client';
 
 export type ExportEntry = {
     name: string;
@@ -60,6 +60,16 @@ export function deleteExport(name: string): Promise<{ success: boolean }> {
     });
 }
 
+export function getExportDownloadUrl(name: string): string {
+    const { apiUris } = getConfig();
+    return buildUrl(apiUris.exports, { action: 'download', name });
+}
+
+export function uploadExport(file: File, onProgress?: (percent: number) => void): Promise<void> {
+    const { apiUris } = getConfig();
+    return apiUpload(apiUris.exports, { file, params: { action: 'upload' }, onProgress });
+}
+
 export function exportsQueryOptions() {
     return queryOptions({
         queryKey: ['exports'],
@@ -83,6 +93,21 @@ export function useDeleteExport() {
     const queryClient = useQueryClient();
     return useMutation({
         mutationFn: deleteExport,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['exports'] });
+        },
+    });
+}
+
+type UploadExportParams = {
+    file: File;
+    onProgress?: (percent: number) => void;
+};
+
+export function useUploadExport() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ file, onProgress }: UploadExportParams) => uploadExport(file, onProgress),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['exports'] });
         },

--- a/src/main/resources/assets/js/routes/dumps.tsx
+++ b/src/main/resources/assets/js/routes/dumps.tsx
@@ -8,13 +8,16 @@ import {
 } from '@tanstack/react-table';
 import {
     ArrowUpCircle,
+    Download,
     Ellipsis,
     HardDrive,
     Plus,
     RotateCcw,
     Trash2,
+    Upload,
 } from 'lucide-react';
-import { type ReactElement, useEffect, useRef, useState } from 'react';
+import type { ChangeEvent, ReactElement } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
     AlertDialog,
     AlertDialogAction,
@@ -62,10 +65,12 @@ import {
 import {
     type Dump,
     dumpsQueryOptions,
+    getDumpDownloadUrl,
     useCreateDump,
     useDeleteDump,
     useLoadDump,
     useUpgradeDump,
+    useUploadDump,
 } from '../lib/api/dumps';
 import { type TaskInfo, type TaskState, taskQueryOptions } from '../lib/api/tasks';
 
@@ -340,6 +345,15 @@ const RowActions = ({ dump, onStartTask }: RowActionsProps): ReactElement => {
                                 Upgrade
                             </DropdownMenuItem>
                         )}
+                        <DropdownMenuItem
+                            onClick={e => {
+                                e.stopPropagation();
+                                window.open(getDumpDownloadUrl(dump.name), '_blank');
+                            }}
+                        >
+                            <Download className="size-4" />
+                            Download
+                        </DropdownMenuItem>
                     </DropdownMenuGroup>
                     <DropdownMenuSeparator />
                     <DropdownMenuGroup>
@@ -511,6 +525,96 @@ const CreateDumpDialog = ({ onStartTask }: CreateDumpDialogProps): ReactElement 
 };
 
 //
+// * UploadDumpDialog
+//
+
+const UploadDumpDialog = (): ReactElement => {
+    const [open, setOpen] = useState(false);
+    const [uploadProgress, setUploadProgress] = useState(0);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const uploadMutation = useUploadDump();
+
+    const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (file == null) return;
+
+        setUploadProgress(0);
+        uploadMutation.mutate({ file, onProgress: setUploadProgress }, {
+            onSuccess: () => {
+                const displayName = file.name.endsWith('.zip') ? file.name.slice(0, -4) : file.name;
+                toast.success(`Dump '${displayName}' uploaded`);
+                setOpen(false);
+                setUploadProgress(0);
+            },
+            onError: (error) => {
+                const message = (error as { message?: string })?.message ?? 'Upload failed';
+                toast.error(message);
+                setUploadProgress(0);
+            },
+        });
+
+        if (fileInputRef.current != null) {
+            fileInputRef.current.value = '';
+        }
+    };
+
+    const handleOpenChange = (nextOpen: boolean) => {
+        if (uploadMutation.isPending) return;
+        setOpen(nextOpen);
+        if (!nextOpen) {
+            setUploadProgress(0);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogTrigger asChild>
+                <Button>
+                    <Upload className="size-4" />
+                    Upload
+                </Button>
+            </DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Upload Dump</DialogTitle>
+                    <DialogDescription>
+                        Upload a ZIP archive containing a dump.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="grid gap-4 py-4">
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept=".zip"
+                        className="hidden"
+                        onChange={handleFileSelect}
+                    />
+                    <Button
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={uploadMutation.isPending}
+                    >
+                        Select ZIP file
+                    </Button>
+                    {uploadMutation.isPending && (
+                        <div className="flex items-center gap-2">
+                            <Progress value={uploadProgress} className="h-2 flex-1" />
+                            <span className="whitespace-nowrap text-muted-foreground text-xs">
+                                {uploadProgress}%
+                            </span>
+                        </div>
+                    )}
+                </div>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button disabled={uploadMutation.isPending}>Close</Button>
+                    </DialogClose>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+//
 // * DumpsPage
 //
 
@@ -600,6 +704,7 @@ const DumpsPage = (): ReactElement => {
             {/* Action toolbar */}
             <div className="flex items-center gap-2 px-4 py-2">
                 <div className="flex-1" />
+                <UploadDumpDialog />
                 <CreateDumpDialog onStartTask={handleStartTask} />
             </div>
 

--- a/src/main/resources/assets/js/routes/exports.tsx
+++ b/src/main/resources/assets/js/routes/exports.tsx
@@ -7,13 +7,16 @@ import {
     useReactTable,
 } from '@tanstack/react-table';
 import {
+    Download,
     Ellipsis,
     FileOutput,
     Import,
     Plus,
     Trash2,
+    Upload,
 } from 'lucide-react';
-import { type ReactElement, useEffect, useRef, useState } from 'react';
+import type { ChangeEvent, ReactElement } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { z } from 'zod';
 import { Button } from '../components/ui/button';
 import { Checkbox } from '../components/ui/checkbox';
@@ -33,6 +36,7 @@ import {
     DropdownMenuContent,
     DropdownMenuGroup,
     DropdownMenuItem,
+    DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '../components/ui/dropdown-menu';
 import { EmptyState } from '../components/ui/empty-state';
@@ -59,9 +63,11 @@ import {
 import {
     type ExportEntry,
     exportsQueryOptions,
+    getExportDownloadUrl,
     useCreateExport,
     useDeleteExport,
     useImportExport,
+    useUploadExport,
 } from '../lib/api/exports';
 import { type Repository, repositoriesQueryOptions } from '../lib/api/repositories';
 import { type TaskInfo, type TaskState, taskQueryOptions } from '../lib/api/tasks';
@@ -267,6 +273,18 @@ const RowActions = ({ exportEntry }: RowActionsProps): ReactElement => {
                     </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
+                    <DropdownMenuGroup>
+                        <DropdownMenuItem
+                            onClick={e => {
+                                e.stopPropagation();
+                                window.open(getExportDownloadUrl(exportEntry.name), '_blank');
+                            }}
+                        >
+                            <Download className="size-4" />
+                            Download
+                        </DropdownMenuItem>
+                    </DropdownMenuGroup>
+                    <DropdownMenuSeparator />
                     <DropdownMenuGroup>
                         <DropdownMenuItem
                             className="text-destructive focus:text-destructive"
@@ -648,6 +666,96 @@ const ImportDialog = ({ exports, repositories, onStartTask }: ImportDialogProps)
 };
 
 //
+// * UploadExportDialog
+//
+
+const UploadExportDialog = (): ReactElement => {
+    const [open, setOpen] = useState(false);
+    const [uploadProgress, setUploadProgress] = useState(0);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const uploadMutation = useUploadExport();
+
+    const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (file == null) return;
+
+        setUploadProgress(0);
+        uploadMutation.mutate({ file, onProgress: setUploadProgress }, {
+            onSuccess: () => {
+                const displayName = file.name.endsWith('.zip') ? file.name.slice(0, -4) : file.name;
+                toast.success(`Export '${displayName}' uploaded`);
+                setOpen(false);
+                setUploadProgress(0);
+            },
+            onError: (error) => {
+                const message = (error as { message?: string })?.message ?? 'Upload failed';
+                toast.error(message);
+                setUploadProgress(0);
+            },
+        });
+
+        if (fileInputRef.current != null) {
+            fileInputRef.current.value = '';
+        }
+    };
+
+    const handleOpenChange = (nextOpen: boolean) => {
+        if (uploadMutation.isPending) return;
+        setOpen(nextOpen);
+        if (!nextOpen) {
+            setUploadProgress(0);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogTrigger asChild>
+                <Button>
+                    <Upload className="size-4" />
+                    Upload
+                </Button>
+            </DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Upload Export</DialogTitle>
+                    <DialogDescription>
+                        Upload a ZIP archive containing an export.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="grid gap-4 py-4">
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept=".zip"
+                        className="hidden"
+                        onChange={handleFileSelect}
+                    />
+                    <Button
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={uploadMutation.isPending}
+                    >
+                        Select ZIP file
+                    </Button>
+                    {uploadMutation.isPending && (
+                        <div className="flex items-center gap-2">
+                            <Progress value={uploadProgress} className="h-2 flex-1" />
+                            <span className="whitespace-nowrap text-muted-foreground text-xs">
+                                {uploadProgress}%
+                            </span>
+                        </div>
+                    )}
+                </div>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button disabled={uploadMutation.isPending}>Close</Button>
+                    </DialogClose>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+//
 // * ExportsPage
 //
 
@@ -734,6 +842,7 @@ const ExportsPage = (): ReactElement => {
             {/* Action toolbar */}
             <div className="flex items-center gap-2 px-4 py-2">
                 <div className="flex-1" />
+                <UploadExportDialog />
                 <ImportDialog exports={exports} repositories={repositories} onStartTask={handleStartTask} />
                 <CreateExportDialog repositories={repositories} onStartTask={handleStartTask} />
             </div>

--- a/src/main/resources/lib/dumps.ts
+++ b/src/main/resources/lib/dumps.ts
@@ -1,3 +1,4 @@
+import type { ByteSource } from '@enonic-types/core';
 import { managementApiRequest } from './management-api';
 
 //
@@ -47,6 +48,14 @@ export function listDumps(): DumpEntry[] {
 
 export function deleteDump(name: string): boolean {
     return dumpManager.delete(name);
+}
+
+export function downloadDump(name: string): ByteSource | null {
+    return dumpManager.download(name);
+}
+
+export function uploadDump(name: string, data: ByteSource): boolean {
+    return dumpManager.upload(name, data as object);
 }
 
 export function createDump(params: CreateDumpParams, authHeader?: string): TaskIdResponse {

--- a/src/main/resources/lib/exports.ts
+++ b/src/main/resources/lib/exports.ts
@@ -1,3 +1,4 @@
+import type { ByteSource } from '@enonic-types/core';
 import { run } from '/lib/xp/context';
 import { exportNodes, importNodes } from '/lib/xp/export';
 import { executeFunction, progress } from '/lib/xp/task';
@@ -51,6 +52,14 @@ export function listExports(): ExportEntry[] {
 
 export function deleteExport(name: string): boolean {
     return exportManager.delete(name);
+}
+
+export function downloadExport(name: string): ByteSource | null {
+    return exportManager.download(name);
+}
+
+export function uploadExport(name: string, data: ByteSource): boolean {
+    return exportManager.upload(name, data as object);
 }
 
 export function createExport(params: CreateExportParams): TaskIdResponse {

--- a/src/main/resources/types/DumpManager.d.ts
+++ b/src/main/resources/types/DumpManager.d.ts
@@ -1,6 +1,8 @@
 declare interface DumpManager {
     list: () => string;
     delete: (name: string) => boolean;
+    download: (name: string) => import('@enonic-types/core').ByteSource | null;
+    upload: (name: string, data: object) => boolean;
 }
 
 interface XpBeans {

--- a/src/main/resources/types/ExportManager.d.ts
+++ b/src/main/resources/types/ExportManager.d.ts
@@ -2,6 +2,8 @@ declare interface ExportManager {
     list: () => string;
     delete: (name: string) => boolean;
     writeMetadata: (name: string, nodeCount: number) => void;
+    download: (name: string) => import('@enonic-types/core').ByteSource | null;
+    upload: (name: string, data: object) => boolean;
 }
 
 interface XpBeans {

--- a/src/test/apis/dumps.test.ts
+++ b/src/test/apis/dumps.test.ts
@@ -5,15 +5,23 @@ vi.mock('/lib/xp/auth', () => ({
     hasRole: vi.fn(() => true),
 }));
 
+vi.mock('/lib/xp/portal', () => ({
+    getMultipartItem: vi.fn(),
+    getMultipartStream: vi.fn(),
+}));
+
 vi.mock('../../main/resources/lib/dumps', () => ({
     listDumps: vi.fn(),
     deleteDump: vi.fn(),
+    downloadDump: vi.fn(),
+    uploadDump: vi.fn(),
     createDump: vi.fn(),
     loadDump: vi.fn(),
     upgradeDump: vi.fn(),
 }));
 
 import { hasRole } from '/lib/xp/auth';
+import { getMultipartItem, getMultipartStream } from '/lib/xp/portal';
 import {
     delete as deleteHandler,
     get,
@@ -22,17 +30,23 @@ import {
 import {
     createDump,
     deleteDump,
+    downloadDump,
     listDumps,
     loadDump,
     upgradeDump,
+    uploadDump,
 } from '../../main/resources/lib/dumps';
 
 const mockedHasRole = vi.mocked(hasRole);
 const mockedListDumps = vi.mocked(listDumps);
 const mockedDeleteDump = vi.mocked(deleteDump);
+const mockedDownloadDump = vi.mocked(downloadDump);
+const mockedUploadDump = vi.mocked(uploadDump);
 const mockedCreateDump = vi.mocked(createDump);
 const mockedLoadDump = vi.mocked(loadDump);
 const mockedUpgradeDump = vi.mocked(upgradeDump);
+const mockedGetMultipartItem = vi.mocked(getMultipartItem);
+const mockedGetMultipartStream = vi.mocked(getMultipartStream);
 
 const AUTH_HEADER = 'Basic c3U6cGFzc3dvcmQ=';
 
@@ -229,5 +243,125 @@ describe('DELETE /dumps', () => {
             params: { name: 'my-dump' },
         } as unknown as Request);
         expect(response.status).toBe(500);
+    });
+});
+
+describe('GET /dumps?action=download', () => {
+    test('returns ZIP stream on success', () => {
+        const fakeStream = { fake: 'stream' };
+        mockedDownloadDump.mockReturnValue(fakeStream as never);
+
+        const response = get({
+            params: { action: 'download', name: 'my-dump' },
+        } as unknown as Request);
+
+        expect(response.status).toBe(200);
+        expect(response.contentType).toBe('application/zip');
+        expect(response.body).toBe(fakeStream);
+        expect(response.headers?.['Content-Disposition']).toBe('attachment; filename="my-dump.zip"');
+    });
+
+    test('requires name parameter', () => {
+        const response = get({
+            params: { action: 'download' },
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 404 when dump not found', () => {
+        mockedDownloadDump.mockReturnValue(null);
+
+        const response = get({
+            params: { action: 'download', name: 'nonexistent' },
+        } as unknown as Request);
+        expect(response.status).toBe(404);
+        expect(parseBody(response).code).toBe('NOT_FOUND');
+    });
+
+    test('returns 403 for non-admin', () => {
+        mockedHasRole.mockReturnValue(false);
+        const response = get({
+            params: { action: 'download', name: 'my-dump' },
+        } as unknown as Request);
+        expect(response.status).toBe(403);
+    });
+});
+
+describe('POST /dumps?action=upload', () => {
+    test('uploads a dump successfully', () => {
+        const fakeStream = { fake: 'stream' };
+        mockedGetMultipartItem.mockReturnValue({ fileName: 'my-dump.zip', contentType: 'application/zip', size: 1024 } as never);
+        mockedGetMultipartStream.mockReturnValue(fakeStream as never);
+        mockedUploadDump.mockReturnValue(true);
+
+        const response = post({
+            headers: {},
+            params: { action: 'upload' },
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(response.status).toBe(200);
+        expect(body.data).toEqual({ success: true, name: 'my-dump' });
+        expect(mockedUploadDump).toHaveBeenCalledWith('my-dump', fakeStream);
+    });
+
+    test('strips .zip extension from filename', () => {
+        mockedGetMultipartItem.mockReturnValue({ fileName: 'test-dump.zip', contentType: 'application/zip', size: 512 } as never);
+        mockedGetMultipartStream.mockReturnValue({} as never);
+        mockedUploadDump.mockReturnValue(true);
+
+        const response = post({
+            headers: {},
+            params: { action: 'upload' },
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(body.data.name).toBe('test-dump');
+    });
+
+    test('rejects filename with invalid characters', () => {
+        mockedGetMultipartItem.mockReturnValue({ fileName: 'bad name.zip', contentType: 'application/zip', size: 512 } as never);
+        mockedGetMultipartStream.mockReturnValue({} as never);
+
+        const response = post({
+            headers: {},
+            params: { action: 'upload' },
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 400 when file is missing', () => {
+        mockedGetMultipartItem.mockReturnValue(null);
+
+        const response = post({
+            headers: {},
+            params: { action: 'upload' },
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 409 when dump already exists', () => {
+        mockedGetMultipartItem.mockReturnValue({ fileName: 'existing.zip', contentType: 'application/zip', size: 1024 } as never);
+        mockedGetMultipartStream.mockReturnValue({} as never);
+        mockedUploadDump.mockReturnValue(false);
+
+        const response = post({
+            headers: {},
+            params: { action: 'upload' },
+        } as unknown as Request);
+        expect(response.status).toBe(409);
+        expect(parseBody(response).code).toBe('CONFLICT');
+    });
+
+    test('returns 403 for non-admin', () => {
+        mockedHasRole.mockReturnValue(false);
+        const response = post({
+            headers: {},
+            params: { action: 'upload' },
+        } as unknown as Request);
+        expect(response.status).toBe(403);
     });
 });

--- a/src/test/apis/exports.test.ts
+++ b/src/test/apis/exports.test.ts
@@ -5,14 +5,22 @@ vi.mock('/lib/xp/auth', () => ({
     hasRole: vi.fn(() => true),
 }));
 
+vi.mock('/lib/xp/portal', () => ({
+    getMultipartItem: vi.fn(),
+    getMultipartStream: vi.fn(),
+}));
+
 vi.mock('../../main/resources/lib/exports', () => ({
     listExports: vi.fn(),
     deleteExport: vi.fn(),
+    downloadExport: vi.fn(),
+    uploadExport: vi.fn(),
     createExport: vi.fn(),
     importExport: vi.fn(),
 }));
 
 import { hasRole } from '/lib/xp/auth';
+import { getMultipartItem, getMultipartStream } from '/lib/xp/portal';
 import {
     delete as deleteHandler,
     get,
@@ -21,15 +29,21 @@ import {
 import {
     createExport,
     deleteExport,
+    downloadExport,
     importExport,
     listExports,
+    uploadExport,
 } from '../../main/resources/lib/exports';
 
 const mockedHasRole = vi.mocked(hasRole);
 const mockedListExports = vi.mocked(listExports);
 const mockedDeleteExport = vi.mocked(deleteExport);
+const mockedDownloadExport = vi.mocked(downloadExport);
+const mockedUploadExport = vi.mocked(uploadExport);
 const mockedCreateExport = vi.mocked(createExport);
 const mockedImportExport = vi.mocked(importExport);
+const mockedGetMultipartItem = vi.mocked(getMultipartItem);
+const mockedGetMultipartStream = vi.mocked(getMultipartStream);
 
 beforeEach(() => {
     vi.clearAllMocks();
@@ -299,5 +313,125 @@ describe('DELETE /exports', () => {
             params: { name: 'my-export' },
         } as unknown as Request);
         expect(response.status).toBe(500);
+    });
+});
+
+describe('GET /exports?action=download', () => {
+    test('returns ZIP stream on success', () => {
+        const fakeStream = { fake: 'stream' };
+        mockedDownloadExport.mockReturnValue(fakeStream as never);
+
+        const response = get({
+            params: { action: 'download', name: 'my-export' },
+        } as unknown as Request);
+
+        expect(response.status).toBe(200);
+        expect(response.contentType).toBe('application/zip');
+        expect(response.body).toBe(fakeStream);
+        expect(response.headers?.['Content-Disposition']).toBe('attachment; filename="my-export.zip"');
+    });
+
+    test('requires name parameter', () => {
+        const response = get({
+            params: { action: 'download' },
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 404 when export not found', () => {
+        mockedDownloadExport.mockReturnValue(null);
+
+        const response = get({
+            params: { action: 'download', name: 'nonexistent' },
+        } as unknown as Request);
+        expect(response.status).toBe(404);
+        expect(parseBody(response).code).toBe('NOT_FOUND');
+    });
+
+    test('returns 403 for non-admin', () => {
+        mockedHasRole.mockReturnValue(false);
+        const response = get({
+            params: { action: 'download', name: 'my-export' },
+        } as unknown as Request);
+        expect(response.status).toBe(403);
+    });
+});
+
+describe('POST /exports?action=upload', () => {
+    test('uploads an export successfully', () => {
+        const fakeStream = { fake: 'stream' };
+        mockedGetMultipartItem.mockReturnValue({ fileName: 'my-export.zip', contentType: 'application/zip', size: 1024 } as never);
+        mockedGetMultipartStream.mockReturnValue(fakeStream as never);
+        mockedUploadExport.mockReturnValue(true);
+
+        const response = post({
+            headers: {},
+            params: { action: 'upload' },
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(response.status).toBe(200);
+        expect(body.data).toEqual({ success: true, name: 'my-export' });
+        expect(mockedUploadExport).toHaveBeenCalledWith('my-export', fakeStream);
+    });
+
+    test('strips .zip extension from filename', () => {
+        mockedGetMultipartItem.mockReturnValue({ fileName: 'test-export.zip', contentType: 'application/zip', size: 512 } as never);
+        mockedGetMultipartStream.mockReturnValue({} as never);
+        mockedUploadExport.mockReturnValue(true);
+
+        const response = post({
+            headers: {},
+            params: { action: 'upload' },
+        } as unknown as Request);
+        const body = parseBody(response);
+
+        expect(body.data.name).toBe('test-export');
+    });
+
+    test('rejects filename with invalid characters', () => {
+        mockedGetMultipartItem.mockReturnValue({ fileName: 'bad name.zip', contentType: 'application/zip', size: 512 } as never);
+        mockedGetMultipartStream.mockReturnValue({} as never);
+
+        const response = post({
+            headers: {},
+            params: { action: 'upload' },
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 400 when file is missing', () => {
+        mockedGetMultipartItem.mockReturnValue(null);
+
+        const response = post({
+            headers: {},
+            params: { action: 'upload' },
+        } as unknown as Request);
+        expect(response.status).toBe(400);
+        expect(parseBody(response).code).toBe('VALIDATION_ERROR');
+    });
+
+    test('returns 409 when export already exists', () => {
+        mockedGetMultipartItem.mockReturnValue({ fileName: 'existing.zip', contentType: 'application/zip', size: 1024 } as never);
+        mockedGetMultipartStream.mockReturnValue({} as never);
+        mockedUploadExport.mockReturnValue(false);
+
+        const response = post({
+            headers: {},
+            params: { action: 'upload' },
+        } as unknown as Request);
+        expect(response.status).toBe(409);
+        expect(parseBody(response).code).toBe('CONFLICT');
+    });
+
+    test('returns 403 for non-admin', () => {
+        mockedHasRole.mockReturnValue(false);
+        const response = post({
+            headers: {},
+            params: { action: 'upload' },
+        } as unknown as Request);
+        expect(response.status).toBe(403);
     });
 });

--- a/src/test/lib/dumps.test.ts
+++ b/src/test/lib/dumps.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 const mockDumpManager = vi.hoisted(() => ({
     list: vi.fn(),
     delete: vi.fn(),
+    download: vi.fn(),
+    upload: vi.fn(),
 }));
 
 vi.hoisted(() => {
@@ -16,9 +18,11 @@ vi.mock('../../main/resources/lib/management-api', () => ({
 import {
     createDump,
     deleteDump,
+    downloadDump,
     listDumps,
     loadDump,
     upgradeDump,
+    uploadDump,
 } from '../../main/resources/lib/dumps';
 import { managementApiRequest } from '../../main/resources/lib/management-api';
 
@@ -100,5 +104,33 @@ describe('upgradeDump', () => {
             body: { name: 'my-dump' },
             authHeader: 'Bearer token',
         });
+    });
+});
+
+describe('downloadDump', () => {
+    test('returns ByteSource from bean', () => {
+        const fakeStream = { fake: 'stream' };
+        mockDumpManager.download.mockReturnValue(fakeStream);
+        expect(downloadDump('my-dump')).toBe(fakeStream);
+        expect(mockDumpManager.download).toHaveBeenCalledWith('my-dump');
+    });
+
+    test('returns null when not found', () => {
+        mockDumpManager.download.mockReturnValue(null);
+        expect(downloadDump('nonexistent')).toBeNull();
+    });
+});
+
+describe('uploadDump', () => {
+    test('returns true on success', () => {
+        mockDumpManager.upload.mockReturnValue(true);
+        const fakeData = { fake: 'data' };
+        expect(uploadDump('my-dump', fakeData as never)).toBe(true);
+        expect(mockDumpManager.upload).toHaveBeenCalledWith('my-dump', fakeData);
+    });
+
+    test('returns false on conflict', () => {
+        mockDumpManager.upload.mockReturnValue(false);
+        expect(uploadDump('existing', {} as never)).toBe(false);
     });
 });

--- a/src/test/lib/exports.test.ts
+++ b/src/test/lib/exports.test.ts
@@ -4,6 +4,8 @@ const mockExportManager = vi.hoisted(() => ({
     list: vi.fn(),
     delete: vi.fn(),
     writeMetadata: vi.fn(),
+    download: vi.fn(),
+    upload: vi.fn(),
 }));
 
 vi.hoisted(() => {
@@ -44,8 +46,10 @@ import { executeFunction, progress } from '/lib/xp/task';
 import {
     createExport,
     deleteExport,
+    downloadExport,
     importExport,
     listExports,
+    uploadExport,
 } from '../../main/resources/lib/exports';
 
 const mockedExecuteFunction = vi.mocked(executeFunction);
@@ -183,5 +187,33 @@ describe('importExport', () => {
         expect(progressCalls[1][0]).toEqual({ current: 5, total: 20 });
         expect(progressCalls[2][0]).toEqual({ current: 8, total: 20 });
         expect(progressCalls[3][0]).toEqual({ current: 15, total: 20 });
+    });
+});
+
+describe('downloadExport', () => {
+    test('returns ByteSource from bean', () => {
+        const fakeStream = { fake: 'stream' };
+        mockExportManager.download.mockReturnValue(fakeStream);
+        expect(downloadExport('my-export')).toBe(fakeStream);
+        expect(mockExportManager.download).toHaveBeenCalledWith('my-export');
+    });
+
+    test('returns null when not found', () => {
+        mockExportManager.download.mockReturnValue(null);
+        expect(downloadExport('nonexistent')).toBeNull();
+    });
+});
+
+describe('uploadExport', () => {
+    test('returns true on success', () => {
+        mockExportManager.upload.mockReturnValue(true);
+        const fakeData = { fake: 'data' };
+        expect(uploadExport('my-export', fakeData as never)).toBe(true);
+        expect(mockExportManager.upload).toHaveBeenCalledWith('my-export', fakeData);
+    });
+
+    test('returns false on conflict', () => {
+        mockExportManager.upload.mockReturnValue(false);
+        expect(uploadExport('existing', {} as never)).toBe(false);
     });
 });


### PR DESCRIPTION
Added ZIP download and upload capabilities to dump and export management across all layers: Kotlin beans, server-side TS handlers, and React frontend.

Backend:
- `zipToByteSource()` and `saveStream()` helpers in `Support.kt`
- `download()` and `upload()` bean methods in `DumpManager` and `ExportManager`
- Atomic temp-file writes with cleanup on failure
- Path traversal protection and directory validation for dumps

API:
- GET `?action=download&name=X` serves ZIP with sanitized `Content-Disposition`
- POST `?action=upload` accepts multipart ZIP via `/lib/xp/portal`
- Upload filename validated against `VALID_NAME_PATTERN`

Frontend:
- `apiUpload()` with XHR progress tracking and timeout handling
- Download dropdown item in row actions for both dumps and exports
- Upload dialog with file picker and progress bar

Tests:
- 30 new test cases across 4 files for download and upload paths

Closes #17

<sub>*Drafted with AI assistance*</sub>
