### PR TITLE
feat: complete system info page #22

### DIFF
--- a/src/main/kotlin/com/enonic/app/datakit/SystemInfoProvider.kt
+++ b/src/main/kotlin/com/enonic/app/datakit/SystemInfoProvider.kt
@@ -1,0 +1,32 @@
+package com.enonic.app.datakit
+
+import com.enonic.xp.home.HomeDir
+import org.osgi.service.component.annotations.Component
+
+@Component(immediate = true)
+class SystemInfoProvider {
+    fun getJavaVersion(): String = System.getProperty("java.version") ?: ""
+
+    fun getJavaVendor(): String = System.getProperty("java.vendor") ?: ""
+
+    fun getOsName(): String = System.getProperty("os.name") ?: ""
+
+    fun getOsArch(): String = System.getProperty("os.arch") ?: ""
+
+    fun getOsVersion(): String = System.getProperty("os.version") ?: ""
+
+    fun getXpHome(): String = HomeDir.get()?.toFile()?.absolutePath ?: ""
+
+    fun getDiskTotal(): Long = diskSpace { it.totalSpace }
+
+    fun getDiskUsable(): Long = diskSpace { it.usableSpace }
+
+    private inline fun diskSpace(read: (java.io.File) -> Long): Long {
+        val home = HomeDir.get()?.toFile() ?: return 0
+        return try {
+            read(home)
+        } catch (_: SecurityException) {
+            0
+        }
+    }
+}

--- a/src/main/resources/apis/system/system.ts
+++ b/src/main/resources/apis/system/system.ts
@@ -4,18 +4,38 @@ import { jsonResponse, requireAdmin } from '../../lib/api';
 
 type SystemInfo = {
     xpVersion: string;
-    appVersion: string;
     appName: string;
+    appVersion: string;
+    javaVersion: string;
+    javaVendor: string;
+    osName: string;
+    osArch: string;
+    osVersion: string;
+    xpHome: string;
+    diskTotal: number;
+    diskUsable: number;
 };
 
 export function get(_req: Request): Response {
     const forbidden = requireAdmin();
     if (forbidden != null) return forbidden;
 
+    const provider = __.newBean<SystemInfoProvider>(
+        'com.enonic.app.datakit.SystemInfoProvider',
+    );
+
     const info: SystemInfo = {
         xpVersion: getVersion(),
-        appVersion: app.version,
         appName: app.name,
+        appVersion: app.version,
+        javaVersion: provider.getJavaVersion(),
+        javaVendor: provider.getJavaVendor(),
+        osName: provider.getOsName(),
+        osArch: provider.getOsArch(),
+        osVersion: provider.getOsVersion(),
+        xpHome: provider.getXpHome(),
+        diskTotal: provider.getDiskTotal(),
+        diskUsable: provider.getDiskUsable(),
     };
 
     return jsonResponse(info);

--- a/src/main/resources/assets/js/lib/api/system.ts
+++ b/src/main/resources/assets/js/lib/api/system.ts
@@ -2,10 +2,18 @@ import { queryOptions } from '@tanstack/react-query';
 import { getConfig } from '../config';
 import { apiFetch } from './client';
 
-type SystemInfo = {
+export type SystemInfo = {
     xpVersion: string;
-    appVersion: string;
     appName: string;
+    appVersion: string;
+    javaVersion: string;
+    javaVendor: string;
+    osName: string;
+    osArch: string;
+    osVersion: string;
+    xpHome: string;
+    diskTotal: number;
+    diskUsable: number;
 };
 
 export function fetchSystemInfo(): Promise<SystemInfo> {

--- a/src/main/resources/assets/js/routes/system.tsx
+++ b/src/main/resources/assets/js/routes/system.tsx
@@ -1,31 +1,293 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute } from '@tanstack/react-router';
-import type { ReactElement } from 'react';
+import {
+    createFileRoute,
+    type ErrorComponentProps,
+} from '@tanstack/react-router';
+import {
+    Boxes,
+    Coffee,
+    ExternalLink,
+    Info,
+    Monitor,
+    Moon,
+    Package,
+    Palette,
+    Sun,
+    SunMoon,
+} from 'lucide-react';
+import type { ReactElement, ReactNode } from 'react';
+import { useTheme } from '../components/theme-provider';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '../components/ui/card';
+import { EmptyState } from '../components/ui/empty-state';
+import { Progress } from '../components/ui/progress';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '../components/ui/select';
 import { systemInfoQueryOptions } from '../lib/api/system';
+
+const DOCS_URL = 'https://developer.enonic.com';
+
+function formatBytes(bytes: number): string {
+    if (bytes <= 0) return '\u2014';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    const value = bytes / 1024 ** i;
+    return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+//
+// * InfoRow
+//
+
+type InfoRowProps = {
+    label: string;
+    children: ReactNode;
+};
+
+const INFO_ROW_NAME = 'InfoRow';
+
+const InfoRow = ({ label, children }: InfoRowProps): ReactElement => {
+    return (
+        <div
+            data-component={INFO_ROW_NAME}
+            className="grid grid-cols-[8rem_1fr] gap-x-4 gap-y-1 text-sm"
+        >
+            <dt className="font-medium text-muted-foreground">{label}</dt>
+            <dd className="break-all">{children}</dd>
+        </div>
+    );
+};
+
+InfoRow.displayName = INFO_ROW_NAME;
+
+//
+// * DiskUsage
+//
+
+type DiskUsageProps = {
+    total: number;
+    usable: number;
+};
+
+const DISK_USAGE_NAME = 'DiskUsage';
+
+const DiskUsage = ({ total, usable }: DiskUsageProps): ReactElement | null => {
+    if (total <= 0) return null;
+
+    const used = Math.max(total - usable, 0);
+    const percent = Math.min(100, Math.round((used / total) * 100));
+
+    return (
+        <div data-component={DISK_USAGE_NAME} className="flex flex-col gap-2">
+            <div className="flex items-center justify-between text-muted-foreground text-xs">
+                <span>
+                    {formatBytes(used)} used of {formatBytes(total)}
+                </span>
+                <span>{percent}%</span>
+            </div>
+            <Progress value={percent} />
+        </div>
+    );
+};
+
+DiskUsage.displayName = DISK_USAGE_NAME;
+
+//
+// * ThemeSettings
+//
+
+const THEME_SETTINGS_NAME = 'ThemeSettings';
+
+const ThemeSettings = (): ReactElement => {
+    const { theme, setTheme } = useTheme();
+
+    return (
+        <div
+            data-component={THEME_SETTINGS_NAME}
+            className="grid grid-cols-[8rem_1fr] items-center gap-x-4 text-sm"
+        >
+            <span className="font-medium text-muted-foreground">Theme</span>
+            <Select
+                value={theme}
+                onValueChange={value =>
+                    setTheme(value as 'light' | 'dark' | 'system')
+                }
+            >
+                <SelectTrigger className="max-w-48" aria-label="Theme">
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value="light">
+                        <span className="flex items-center gap-2">
+                            <Sun className="size-4" />
+                            Light
+                        </span>
+                    </SelectItem>
+                    <SelectItem value="dark">
+                        <span className="flex items-center gap-2">
+                            <Moon className="size-4" />
+                            Dark
+                        </span>
+                    </SelectItem>
+                    <SelectItem value="system">
+                        <span className="flex items-center gap-2">
+                            <SunMoon className="size-4" />
+                            System
+                        </span>
+                    </SelectItem>
+                </SelectContent>
+            </Select>
+        </div>
+    );
+};
+
+ThemeSettings.displayName = THEME_SETTINGS_NAME;
+
+//
+// * SystemPage
+//
 
 const SYSTEM_PAGE_NAME = 'SystemPage';
 
 const SystemPage = (): ReactElement => {
-    const { data: systemInfo } = useSuspenseQuery(systemInfoQueryOptions());
+    const { data: info } = useSuspenseQuery(systemInfoQueryOptions());
 
     return (
-        <div data-component={SYSTEM_PAGE_NAME} className="flex flex-col gap-4">
-            <dl className="grid max-w-md grid-cols-[auto_1fr] gap-x-4 gap-y-2 px-4 pt-4 text-sm">
-                <dt className="font-medium text-muted-foreground">XP Version</dt>
-                <dd>{systemInfo.xpVersion}</dd>
-                <dt className="font-medium text-muted-foreground">App Version</dt>
-                <dd>{systemInfo.appVersion}</dd>
-                <dt className="font-medium text-muted-foreground">App Name</dt>
-                <dd className="font-mono text-xs">{systemInfo.appName}</dd>
-            </dl>
+        <div
+            data-component={SYSTEM_PAGE_NAME}
+            className="flex flex-col gap-4 p-4"
+        >
+            <div className="grid gap-4 md:grid-cols-2">
+                <SystemCard
+                    icon={<Boxes className="size-5" />}
+                    title="XP Runtime"
+                >
+                    <InfoRow label="Version">{info.xpVersion}</InfoRow>
+                    <InfoRow label="Home">
+                        <span className="font-mono text-xs">{info.xpHome}</span>
+                    </InfoRow>
+                    <DiskUsage total={info.diskTotal} usable={info.diskUsable} />
+                </SystemCard>
+
+                <SystemCard
+                    icon={<Package className="size-5" />}
+                    title="Application"
+                >
+                    <InfoRow label="Key">
+                        <span className="font-mono text-xs">{info.appName}</span>
+                    </InfoRow>
+                    <InfoRow label="Version">{info.appVersion}</InfoRow>
+                </SystemCard>
+
+                <SystemCard
+                    icon={<Coffee className="size-5" />}
+                    title="Java Runtime"
+                >
+                    <InfoRow label="Version">{info.javaVersion}</InfoRow>
+                    <InfoRow label="Vendor">{info.javaVendor}</InfoRow>
+                </SystemCard>
+
+                <SystemCard
+                    icon={<Monitor className="size-5" />}
+                    title="Operating System"
+                >
+                    <InfoRow label="Name">{info.osName}</InfoRow>
+                    <InfoRow label="Architecture">{info.osArch}</InfoRow>
+                    <InfoRow label="Version">{info.osVersion}</InfoRow>
+                </SystemCard>
+            </div>
+
+            <SystemCard
+                icon={<Palette className="size-5" />}
+                title="Appearance"
+            >
+                <ThemeSettings />
+            </SystemCard>
+
+            <div className="flex items-center justify-end px-1">
+                <a
+                    href={DOCS_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 text-muted-foreground text-sm hover:text-foreground"
+                >
+                    Enonic documentation
+                    <ExternalLink className="size-3.5" />
+                </a>
+            </div>
         </div>
     );
 };
 
 SystemPage.displayName = SYSTEM_PAGE_NAME;
 
+//
+// * SystemCard
+//
+
+type SystemCardProps = {
+    icon: ReactNode;
+    title: string;
+    children: ReactNode;
+};
+
+const SYSTEM_CARD_NAME = 'SystemCard';
+
+const SystemCard = ({ icon, title, children }: SystemCardProps): ReactElement => {
+    return (
+        <Card data-component={SYSTEM_CARD_NAME}>
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg">
+                    {icon}
+                    {title}
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                <dl className="flex flex-col gap-3">{children}</dl>
+            </CardContent>
+        </Card>
+    );
+};
+
+SystemCard.displayName = SYSTEM_CARD_NAME;
+
+//
+// * SystemError
+//
+
+const SYSTEM_ERROR_NAME = 'SystemError';
+
+const SystemError = ({ error }: ErrorComponentProps): ReactElement => {
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+
+    return (
+        <div
+            data-component={SYSTEM_ERROR_NAME}
+            className="flex flex-col gap-4 p-4"
+        >
+            <EmptyState
+                icon={Info}
+                title="Failed to load system info"
+                description={message}
+            />
+        </div>
+    );
+};
+
+SystemError.displayName = SYSTEM_ERROR_NAME;
+
 export const Route = createFileRoute('/system')({
     loader: ({ context: { queryClient } }) =>
         queryClient.ensureQueryData(systemInfoQueryOptions()),
     component: SystemPage,
+    errorComponent: SystemError,
 });

--- a/src/main/resources/types/SystemInfoProvider.d.ts
+++ b/src/main/resources/types/SystemInfoProvider.d.ts
@@ -1,0 +1,14 @@
+declare interface SystemInfoProvider {
+    getJavaVersion: () => string;
+    getJavaVendor: () => string;
+    getOsName: () => string;
+    getOsArch: () => string;
+    getOsVersion: () => string;
+    getXpHome: () => string;
+    getDiskTotal: () => number;
+    getDiskUsable: () => number;
+}
+
+interface XpBeans {
+    'com.enonic.app.datakit.SystemInfoProvider': SystemInfoProvider;
+}

--- a/src/test/assets/js/routes/system.test.tsx
+++ b/src/test/assets/js/routes/system.test.tsx
@@ -38,13 +38,26 @@ function getSystemPage(): HTMLElement {
     return el as HTMLElement;
 }
 
+function buildSystemInfo(overrides?: Partial<Record<string, unknown>>) {
+    return {
+        xpVersion: '8.0.0',
+        appName: 'com.enonic.app.datakit',
+        appVersion: '1.2.3',
+        javaVersion: '17.0.9',
+        javaVendor: 'Eclipse Adoptium',
+        osName: 'Linux',
+        osArch: 'amd64',
+        osVersion: '6.1.0',
+        xpHome: '/opt/xp/home',
+        diskTotal: 0,
+        diskUsable: 0,
+        ...overrides,
+    };
+}
+
 describe('SystemPage', () => {
     it('should render system info from API', async () => {
-        mockedApiFetch.mockResolvedValue({
-            xpVersion: '8.0.0',
-            appVersion: '1.2.3',
-            appName: 'com.enonic.app.datakit',
-        });
+        mockedApiFetch.mockResolvedValue(buildSystemInfo());
 
         renderRoute({ initialLocation: '/system' });
 
@@ -54,14 +67,15 @@ describe('SystemPage', () => {
 
         expect(screen.getByText('1.2.3')).toBeInTheDocument();
         expect(screen.getByText('com.enonic.app.datakit')).toBeInTheDocument();
+        expect(screen.getByText('17.0.9')).toBeInTheDocument();
+        expect(screen.getByText('Eclipse Adoptium')).toBeInTheDocument();
+        expect(screen.getByText('Linux')).toBeInTheDocument();
+        expect(screen.getByText('amd64')).toBeInTheDocument();
+        expect(screen.getByText('/opt/xp/home')).toBeInTheDocument();
     });
 
-    it('should display correct labels', async () => {
-        mockedApiFetch.mockResolvedValue({
-            xpVersion: '8.0.0',
-            appVersion: '1.0.0',
-            appName: 'test-app',
-        });
+    it('should display card titles', async () => {
+        mockedApiFetch.mockResolvedValue(buildSystemInfo());
 
         renderRoute({ initialLocation: '/system' });
 
@@ -70,8 +84,58 @@ describe('SystemPage', () => {
         });
 
         const page = within(getSystemPage());
-        expect(page.getByText('XP Version')).toBeInTheDocument();
-        expect(page.getByText('App Version')).toBeInTheDocument();
-        expect(page.getByText('App Name')).toBeInTheDocument();
+        expect(page.getByText('XP Runtime')).toBeInTheDocument();
+        expect(page.getByText('Application')).toBeInTheDocument();
+        expect(page.getByText('Java Runtime')).toBeInTheDocument();
+        expect(page.getByText('Operating System')).toBeInTheDocument();
+        expect(page.getByText('Appearance')).toBeInTheDocument();
+    });
+
+    it('should render disk usage when diskTotal > 0', async () => {
+        mockedApiFetch.mockResolvedValue(
+            buildSystemInfo({
+                diskTotal: 100 * 1024 ** 3,
+                diskUsable: 40 * 1024 ** 3,
+            }),
+        );
+
+        renderRoute({ initialLocation: '/system' });
+
+        await waitFor(() => {
+            getSystemPage();
+        });
+
+        const page = within(getSystemPage());
+        expect(page.getByText('60%')).toBeInTheDocument();
+        expect(page.getByText(/used of/)).toBeInTheDocument();
+    });
+
+    it('should hide disk usage when diskTotal is 0', async () => {
+        mockedApiFetch.mockResolvedValue(buildSystemInfo());
+
+        renderRoute({ initialLocation: '/system' });
+
+        await waitFor(() => {
+            getSystemPage();
+        });
+
+        const page = within(getSystemPage());
+        expect(page.queryByText(/used of/)).not.toBeInTheDocument();
+    });
+
+    it('should link to Enonic documentation', async () => {
+        mockedApiFetch.mockResolvedValue(buildSystemInfo());
+
+        renderRoute({ initialLocation: '/system' });
+
+        await waitFor(() => {
+            getSystemPage();
+        });
+
+        const link = within(getSystemPage()).getByRole('link', {
+            name: /Enonic documentation/i,
+        });
+        expect(link).toHaveAttribute('href', 'https://developer.enonic.com');
+        expect(link).toHaveAttribute('target', '_blank');
     });
 });


### PR DESCRIPTION
Added `SystemInfoProvider.kt` Kotlin bean exposing Java runtime properties, OS info, XP home path, and disk space via `HomeDir.get()` and `System.getProperty()`.
Extended `apis/system/system.ts` to call the bean via `__.newBean()` and return the full `SystemInfo` shape.
Rebuilt `routes/system.tsx` as a card-based dashboard with five cards: XP Runtime (with optional disk progress bar), Application, Java Runtime, OS, and Appearance (theme Select + docs link).
Updated client type in `lib/api/system.ts` and `system.test.tsx` to match the expanded response shape.

Closes #22

<sub>*Drafted with AI assistance*</sub>
