### PR TITLE
feat: add client-side NoQL query validation with inline error display #43

### DIFF
--- a/src/main/resources/assets/js/lib/noql/suggest.ts
+++ b/src/main/resources/assets/js/lib/noql/suggest.ts
@@ -1,0 +1,46 @@
+function levenshtein(a: string, b: string): number {
+    if (a === b) return 0;
+    if (a.length === 0) return b.length;
+    if (b.length === 0) return a.length;
+
+    const rows = a.length + 1;
+    const cols = b.length + 1;
+    const dp: number[] = new Array(rows * cols);
+
+    for (let i = 0; i < rows; i++) dp[i * cols] = i;
+    for (let j = 0; j < cols; j++) dp[j] = j;
+
+    for (let i = 1; i < rows; i++) {
+        for (let j = 1; j < cols; j++) {
+            const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+            dp[i * cols + j] = Math.min(
+                dp[(i - 1) * cols + j] + 1,
+                dp[i * cols + (j - 1)] + 1,
+                dp[(i - 1) * cols + (j - 1)] + cost,
+            );
+        }
+    }
+
+    return dp[rows * cols - 1];
+}
+
+export function closestName(input: string, candidates: string[]): string | undefined {
+    if (input.length === 0 || candidates.length === 0) return undefined;
+
+    const normalized = input.toLowerCase();
+    const cutoff = Math.max(1, Math.min(2, Math.ceil(input.length / 3)));
+
+    let bestName: string | undefined;
+    let bestDistance = cutoff + 1;
+
+    for (const candidate of candidates) {
+        const distance = levenshtein(normalized, candidate.toLowerCase());
+        if (distance === 0) return candidate;
+        if (distance <= cutoff && distance < bestDistance) {
+            bestName = candidate;
+            bestDistance = distance;
+        }
+    }
+
+    return bestName;
+}

--- a/src/main/resources/assets/js/lib/noql/tokenizer.ts
+++ b/src/main/resources/assets/js/lib/noql/tokenizer.ts
@@ -1,0 +1,157 @@
+import type { Position, Token, ValidationError } from './types';
+
+const KEYWORDS = new Set([
+    'AND',
+    'OR',
+    'NOT',
+    'LIKE',
+    'IN',
+    'ASC',
+    'DESC',
+    'ORDER',
+    'BY',
+    'COLLATE',
+]);
+
+const IDENT_START = /[a-zA-Z_*@]/;
+const IDENT_REST = /[a-zA-Z0-9\-_/.*@]/;
+const DIGIT = /[0-9]/;
+
+function isWhitespace(ch: string): boolean {
+    return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r';
+}
+
+export function tokenize(input: string): Token[] | ValidationError {
+    const tokens: Token[] = [];
+    let i = 0;
+    const len = input.length;
+
+    while (i < len) {
+        const ch = input[i];
+
+        if (isWhitespace(ch)) {
+            i++;
+            continue;
+        }
+
+        // * String literal
+        if (ch === "'" || ch === '"') {
+            const start = i;
+            const quote = ch;
+            i++;
+            while (i < len && input[i] !== quote) i++;
+            if (i >= len) {
+                return {
+                    message: `Unterminated string starting at position ${start}`,
+                    position: { start, end: len },
+                };
+            }
+            i++; // consume closing quote
+            tokens.push({
+                type: 'string',
+                value: input.slice(start + 1, i - 1),
+                position: { start, end: i },
+            });
+            continue;
+        }
+
+        // * Number literal (optionally signed, followed by a digit)
+        if (
+            DIGIT.test(ch) ||
+            ((ch === '-' || ch === '+') && i + 1 < len && DIGIT.test(input[i + 1]))
+        ) {
+            const start = i;
+            if (ch === '-' || ch === '+') i++;
+            while (i < len && DIGIT.test(input[i])) i++;
+            if (i < len && input[i] === '.') {
+                i++;
+                const fracStart = i;
+                while (i < len && DIGIT.test(input[i])) i++;
+                if (i === fracStart) {
+                    return {
+                        message: `Malformed number at position ${start}`,
+                        position: { start, end: i },
+                    };
+                }
+            }
+            tokens.push({
+                type: 'number',
+                value: input.slice(start, i),
+                position: { start, end: i },
+            });
+            continue;
+        }
+
+        // * Identifier or keyword
+        if (IDENT_START.test(ch)) {
+            const start = i;
+            i++;
+            while (i < len && IDENT_REST.test(input[i])) i++;
+            const raw = input.slice(start, i);
+            const upper = raw.toUpperCase();
+            const position: Position = { start, end: i };
+            if (KEYWORDS.has(upper)) {
+                tokens.push({ type: 'keyword', value: upper, position });
+            } else {
+                tokens.push({ type: 'identifier', value: raw, position });
+            }
+            continue;
+        }
+
+        // * Parentheses and comma
+        if (ch === '(') {
+            tokens.push({ type: 'lparen', value: '(', position: { start: i, end: i + 1 } });
+            i++;
+            continue;
+        }
+        if (ch === ')') {
+            tokens.push({ type: 'rparen', value: ')', position: { start: i, end: i + 1 } });
+            i++;
+            continue;
+        }
+        if (ch === ',') {
+            tokens.push({ type: 'comma', value: ',', position: { start: i, end: i + 1 } });
+            i++;
+            continue;
+        }
+
+        // * Comparison operators
+        if (ch === '=') {
+            tokens.push({ type: 'operator', value: '=', position: { start: i, end: i + 1 } });
+            i++;
+            continue;
+        }
+        if (ch === '!') {
+            if (i + 1 < len && input[i + 1] === '=') {
+                tokens.push({ type: 'operator', value: '!=', position: { start: i, end: i + 2 } });
+                i += 2;
+                continue;
+            }
+            return {
+                message: `Invalid character '!' at position ${i} — expected '!='`,
+                position: { start: i, end: i + 1 },
+            };
+        }
+        if (ch === '>' || ch === '<') {
+            if (i + 1 < len && input[i + 1] === '=') {
+                tokens.push({
+                    type: 'operator',
+                    value: `${ch}=`,
+                    position: { start: i, end: i + 2 },
+                });
+                i += 2;
+            } else {
+                tokens.push({ type: 'operator', value: ch, position: { start: i, end: i + 1 } });
+                i++;
+            }
+            continue;
+        }
+
+        return {
+            message: `Invalid character '${ch}' at position ${i}`,
+            position: { start: i, end: i + 1 },
+        };
+    }
+
+    return tokens;
+}

--- a/src/main/resources/assets/js/lib/noql/types.ts
+++ b/src/main/resources/assets/js/lib/noql/types.ts
@@ -1,0 +1,26 @@
+export type Position = {
+    start: number;
+    end: number;
+};
+
+export type TokenType =
+    | 'identifier'
+    | 'string'
+    | 'number'
+    | 'keyword'
+    | 'operator'
+    | 'lparen'
+    | 'rparen'
+    | 'comma';
+
+export type Token = {
+    type: TokenType;
+    value: string;
+    position: Position;
+};
+
+export type ValidationError = {
+    message: string;
+    position?: Position;
+    suggestion?: string;
+};

--- a/src/main/resources/assets/js/lib/noql/validator.ts
+++ b/src/main/resources/assets/js/lib/noql/validator.ts
@@ -1,0 +1,426 @@
+import { closestName } from './suggest';
+import { tokenize } from './tokenizer';
+import type { Token, ValidationError } from './types';
+
+type RangeArity = { min: number; max: number };
+type FunctionCategory = 'value' | 'constraint' | 'sort';
+
+const VALUE_FUNCTIONS: Record<string, number> = {
+    geoPoint: 1,
+    instant: 1,
+    dateTime: 1,
+    localDateTime: 1,
+    time: 1,
+    date: 1,
+};
+
+const CONSTRAINT_FUNCTIONS: Record<string, RangeArity> = {
+    fulltext: { min: 2, max: 4 },
+    ngram: { min: 2, max: 4 },
+    stemmed: { min: 2, max: 4 },
+    range: { min: 3, max: 5 },
+    pathMatch: { min: 2, max: 3 },
+};
+
+const SORT_FUNCTIONS: Record<string, number | RangeArity> = {
+    score: 0,
+    geoDistance: { min: 2, max: 3 },
+};
+
+const ALL_FUNCTION_NAMES = [
+    ...Object.keys(VALUE_FUNCTIONS),
+    ...Object.keys(CONSTRAINT_FUNCTIONS),
+    ...Object.keys(SORT_FUNCTIONS),
+];
+
+class ParseError extends Error {
+    constructor(readonly error: ValidationError) {
+        super(error.message);
+    }
+}
+
+class Parser {
+    private i = 0;
+    constructor(private readonly tokens: Token[]) {}
+
+    private peek(offset = 0): Token | undefined {
+        return this.tokens[this.i + offset];
+    }
+
+    private consume(): Token {
+        const t = this.tokens[this.i];
+        this.i++;
+        return t;
+    }
+
+    private isEof(): boolean {
+        return this.i >= this.tokens.length;
+    }
+
+    private matchKeyword(kw: string): boolean {
+        const t = this.peek();
+        return t?.type === 'keyword' && t.value === kw;
+    }
+
+    parseQuery(): void {
+        if (this.isEof()) return;
+
+        if (this.matchKeyword('ORDER')) {
+            this.parseOrderBy();
+        } else {
+            this.parseConstraint();
+            if (this.matchKeyword('ORDER')) {
+                this.parseOrderBy();
+            }
+        }
+
+        if (!this.isEof()) {
+            const t = this.peek();
+            if (t != null) {
+                throw new ParseError({
+                    message: `Unexpected token '${t.value}' at position ${t.position.start}`,
+                    position: t.position,
+                });
+            }
+        }
+    }
+
+    private parseConstraint(): void {
+        this.parseAndExpr();
+        while (this.matchKeyword('OR')) {
+            this.consume();
+            this.parseAndExpr();
+        }
+    }
+
+    private parseAndExpr(): void {
+        this.parseNotExpr();
+        while (this.matchKeyword('AND')) {
+            this.consume();
+            this.parseNotExpr();
+        }
+    }
+
+    private parseNotExpr(): void {
+        if (this.matchKeyword('NOT')) {
+            this.consume();
+            this.parseNotExpr();
+            return;
+        }
+        this.parseUnit();
+    }
+
+    private parseUnit(): void {
+        const t = this.peek();
+        if (t == null) {
+            throw new ParseError({ message: 'Incomplete expression' });
+        }
+        if (t.type === 'lparen') {
+            this.consume();
+            this.parseConstraint();
+            const rp = this.peek();
+            if (rp == null || rp.type !== 'rparen') {
+                throw new ParseError({
+                    message: `Expected ')' to close '(' at position ${t.position.start}`,
+                    position: t.position,
+                });
+            }
+            this.consume();
+            return;
+        }
+        if (t.type === 'identifier') {
+            if (this.peek(1)?.type === 'lparen') {
+                this.parseFunctionCall('constraint');
+                return;
+            }
+            this.parseCompare();
+            return;
+        }
+        throw new ParseError({
+            message: `Unexpected token '${t.value}' at position ${t.position.start}`,
+            position: t.position,
+        });
+    }
+
+    private parseCompare(): void {
+        const field = this.consume();
+        const op = this.peek();
+        if (op == null) {
+            throw new ParseError({
+                message: `Incomplete expression after '${field.value}'`,
+                position: field.position,
+            });
+        }
+        if (op.type === 'operator') {
+            this.consume();
+            this.parseValue();
+            return;
+        }
+        if (op.type === 'keyword') {
+            if (op.value === 'LIKE') {
+                this.consume();
+                this.parseValue();
+                return;
+            }
+            if (op.value === 'IN') {
+                this.consume();
+                this.parseValueList();
+                return;
+            }
+            if (op.value === 'NOT') {
+                this.consume();
+                const next = this.peek();
+                if (next == null || next.type !== 'keyword' || (next.value !== 'LIKE' && next.value !== 'IN')) {
+                    throw new ParseError({
+                        message: `Expected 'LIKE' or 'IN' after 'NOT' at position ${op.position.start}`,
+                        position: op.position,
+                    });
+                }
+                this.consume();
+                if (next.value === 'LIKE') this.parseValue();
+                else this.parseValueList();
+                return;
+            }
+        }
+        throw new ParseError({
+            message: `Expected operator after '${field.value}' at position ${op.position.start}`,
+            position: op.position,
+        });
+    }
+
+    private parseValue(): void {
+        const t = this.peek();
+        if (t == null) {
+            throw new ParseError({ message: 'Incomplete expression — expected a value' });
+        }
+        if (t.type === 'string' || t.type === 'number') {
+            this.consume();
+            return;
+        }
+        if (t.type === 'identifier' && this.peek(1)?.type === 'lparen') {
+            this.parseFunctionCall('value');
+            return;
+        }
+        throw new ParseError({
+            message: `Expected a value at position ${t.position.start}`,
+            position: t.position,
+        });
+    }
+
+    private parseValueList(): void {
+        const lp = this.peek();
+        if (lp == null || lp.type !== 'lparen') {
+            throw new ParseError({
+                message: `Expected '(' to start value list`,
+                position: lp?.position,
+            });
+        }
+        this.consume();
+        this.parseValue();
+        while (this.peek()?.type === 'comma') {
+            this.consume();
+            this.parseValue();
+        }
+        const rp = this.peek();
+        if (rp == null || rp.type !== 'rparen') {
+            throw new ParseError({
+                message: `Expected ')' to close '(' at position ${lp.position.start}`,
+                position: lp.position,
+            });
+        }
+        this.consume();
+    }
+
+    private parseFunctionCall(category: FunctionCategory): void {
+        const name = this.consume();
+        const lp = this.consume();
+        let argCount = 0;
+        if (this.peek()?.type !== 'rparen') {
+            this.parseFunctionArg();
+            argCount++;
+            while (this.peek()?.type === 'comma') {
+                this.consume();
+                this.parseFunctionArg();
+                argCount++;
+            }
+        }
+        const rp = this.peek();
+        if (rp == null || rp.type !== 'rparen') {
+            throw new ParseError({
+                message: `Expected ')' to close '(' at position ${lp.position.start}`,
+                position: lp.position,
+            });
+        }
+        this.consume();
+        this.validateFunctionSemantics(name, argCount, category);
+    }
+
+    private parseFunctionArg(): void {
+        const t = this.peek();
+        if (t == null) {
+            throw new ParseError({ message: 'Incomplete function argument' });
+        }
+        if (t.type === 'string' || t.type === 'number') {
+            this.consume();
+            return;
+        }
+        if (t.type === 'identifier') {
+            if (this.peek(1)?.type === 'lparen') {
+                this.parseFunctionCall('value');
+                return;
+            }
+            this.consume();
+            return;
+        }
+        throw new ParseError({
+            message: `Expected a value at position ${t.position.start}`,
+            position: t.position,
+        });
+    }
+
+    private parseOrderBy(): void {
+        this.consume(); // ORDER
+        const by = this.peek();
+        if (by == null || by.type !== 'keyword' || by.value !== 'BY') {
+            throw new ParseError({
+                message: `Expected 'BY' after 'ORDER'`,
+                position: by?.position,
+            });
+        }
+        this.consume();
+        this.parseOrderElement();
+        while (this.peek()?.type === 'comma') {
+            this.consume();
+            this.parseOrderElement();
+        }
+    }
+
+    private parseOrderElement(): void {
+        const t = this.peek();
+        if (t == null) {
+            throw new ParseError({ message: `Expected field or function in ORDER BY` });
+        }
+        if (t.type !== 'identifier') {
+            throw new ParseError({
+                message: `Expected field or function in ORDER BY at position ${t.position.start}`,
+                position: t.position,
+            });
+        }
+        if (this.peek(1)?.type === 'lparen') {
+            this.parseFunctionCall('sort');
+        } else {
+            this.consume();
+        }
+        if (this.matchKeyword('ASC') || this.matchKeyword('DESC')) {
+            this.consume();
+        }
+        if (this.matchKeyword('COLLATE')) {
+            this.consume();
+            const s = this.peek();
+            if (s == null || s.type !== 'string') {
+                throw new ParseError({
+                    message: `Expected a string literal after 'COLLATE'`,
+                    position: s?.position,
+                });
+            }
+            this.consume();
+        }
+    }
+
+    private validateFunctionSemantics(name: Token, argCount: number, category: FunctionCategory): void {
+        const nameStr = name.value;
+        const valueArity = VALUE_FUNCTIONS[nameStr];
+        const constraintArity = CONSTRAINT_FUNCTIONS[nameStr];
+        const sortArity = SORT_FUNCTIONS[nameStr];
+
+        const isValue = valueArity != null;
+        const isConstraint = constraintArity != null;
+        const isSort = sortArity != null;
+
+        if (!((isValue || isConstraint ) || isSort)) {
+            const suggestion = closestName(nameStr, ALL_FUNCTION_NAMES);
+            throw new ParseError({
+                message: `Unknown function '${nameStr}'`,
+                position: name.position,
+                suggestion: suggestion != null ? `Did you mean '${suggestion}'?` : undefined,
+            });
+        }
+
+        const correctCategory =
+            (category === 'value' && isValue) ||
+            (category === 'constraint' && isConstraint) ||
+            (category === 'sort' && isSort);
+
+        if (!correctCategory) {
+            const sourceLabel = isValue ? 'a value function' : isConstraint ? 'a constraint function' : 'an ORDER BY function';
+            const destLabel = category === 'value' ? 'a value' : category === 'constraint' ? 'a constraint' : 'ORDER BY';
+            throw new ParseError({
+                message: `${nameStr}() is ${sourceLabel} and cannot be used as ${destLabel}`,
+                position: name.position,
+            });
+        }
+
+        if (category === 'value') {
+            if (argCount !== valueArity) {
+                throw new ParseError({
+                    message: formatArityMessage(nameStr, valueArity, argCount),
+                    position: name.position,
+                });
+            }
+            return;
+        }
+
+        if (category === 'constraint') {
+            const { min, max } = constraintArity;
+            if (argCount < min || argCount > max) {
+                throw new ParseError({
+                    message: formatArityMessage(nameStr, { min, max }, argCount),
+                    position: name.position,
+                });
+            }
+            return;
+        }
+
+        if (typeof sortArity === 'number') {
+            if (argCount !== sortArity) {
+                throw new ParseError({
+                    message: formatArityMessage(nameStr, sortArity, argCount),
+                    position: name.position,
+                });
+            }
+            return;
+        }
+
+        const { min, max } = sortArity;
+        if (argCount < min || argCount > max) {
+            throw new ParseError({
+                message: formatArityMessage(nameStr, { min, max }, argCount),
+                position: name.position,
+            });
+        }
+    }
+}
+
+function formatArityMessage(name: string, expected: number | RangeArity, got: number): string {
+    if (typeof expected === 'number') {
+        const word = expected === 1 ? 'argument' : 'arguments';
+        return `${name}() takes ${expected} ${word}, got ${got}`;
+    }
+    const range = expected.min === expected.max ? `${expected.min}` : `${expected.min}\u2013${expected.max}`;
+    return `${name}() takes ${range} arguments, got ${got}`;
+}
+
+export function validate(query: string): ValidationError | null {
+    const tokenResult = tokenize(query);
+    if (!Array.isArray(tokenResult)) return tokenResult;
+    if (tokenResult.length === 0) return null;
+
+    const parser = new Parser(tokenResult);
+    try {
+        parser.parseQuery();
+        return null;
+    } catch (e) {
+        if (e instanceof ParseError) return e.error;
+        throw e;
+    }
+}

--- a/src/main/resources/assets/js/routes/search.tsx
+++ b/src/main/resources/assets/js/routes/search.tsx
@@ -40,6 +40,8 @@ import {
 import { type Repository, repositoriesQueryOptions } from '../lib/api/repositories';
 import { executeSearch, type SearchHit, type SearchParams, type SearchResponse } from '../lib/api/search';
 import { downloadBlob, type ExportColumn, type ExportFormat, toCSV, toTSV } from '../lib/export';
+import type { ValidationError as NoqlValidationError } from '../lib/noql/types';
+import { validate as validateNoql } from '../lib/noql/validator';
 
 const SEARCH_PAGE_NAME = 'SearchPage';
 
@@ -89,6 +91,14 @@ const SearchPage = (): ReactElement => {
     const [result, setResult] = useState<SearchResponse | null>(null);
     const [resultParams, setResultParams] = useState<SearchParams | null>(null);
     const [error, setError] = useState<string | null>(null);
+    const [validationError, setValidationError] = useState<NoqlValidationError | null>(null);
+
+    useEffect(() => {
+        const handle = setTimeout(() => {
+            setValidationError(validateNoql(query));
+        }, 300);
+        return () => clearTimeout(handle);
+    }, [query]);
 
     const selectedRepo = useMemo(
         () => repositories.find((r: Repository) => r.id === repoId),
@@ -393,6 +403,13 @@ const SearchPage = (): ReactElement => {
                         </button>
                     )}
                 </div>
+
+                {validationError != null && (
+                    <p className="mt-2 max-w-[460px] text-destructive text-sm">
+                        {validationError.message}
+                        {validationError.suggestion != null && ` ${validationError.suggestion}`}
+                    </p>
+                )}
             </div>
 
             {error != null && (

--- a/src/test/assets/js/lib/noql/suggest.test.ts
+++ b/src/test/assets/js/lib/noql/suggest.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { closestName } from '../../../../../main/resources/assets/js/lib/noql/suggest';
+
+const VALUE_FUNCS = ['geoPoint', 'instant', 'dateTime', 'localDateTime', 'time', 'date'];
+const ALL_FUNCS = [
+    ...VALUE_FUNCS,
+    'fulltext',
+    'ngram',
+    'stemmed',
+    'range',
+    'pathMatch',
+    'score',
+    'geoDistance',
+];
+
+describe('closestName', () => {
+    it('should suggest fulltext for a one-char typo', () => {
+        expect(closestName('fultext', ALL_FUNCS)).toBe('fulltext');
+    });
+
+    it('should suggest score for a one-char typo', () => {
+        expect(closestName('scoor', ALL_FUNCS)).toBe('score');
+    });
+
+    it('should suggest geoDistance for a two-char typo', () => {
+        expect(closestName('geoDistnc', ALL_FUNCS)).toBe('geoDistance');
+    });
+
+    it('should return undefined when no candidate is within the cutoff', () => {
+        expect(closestName('xyz', ALL_FUNCS)).toBeUndefined();
+    });
+
+    it('should return undefined for an empty input', () => {
+        expect(closestName('', ALL_FUNCS)).toBeUndefined();
+    });
+
+    it('should be case-insensitive on the input', () => {
+        expect(closestName('FULTEXT', ALL_FUNCS)).toBe('fulltext');
+    });
+
+    it('should return exact match when input matches a candidate', () => {
+        expect(closestName('fulltext', ALL_FUNCS)).toBe('fulltext');
+    });
+
+    it('should return undefined when candidates list is empty', () => {
+        expect(closestName('fulltext', [])).toBeUndefined();
+    });
+});

--- a/src/test/assets/js/lib/noql/tokenizer.test.ts
+++ b/src/test/assets/js/lib/noql/tokenizer.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import { tokenize } from '../../../../../main/resources/assets/js/lib/noql/tokenizer';
+import type { Token } from '../../../../../main/resources/assets/js/lib/noql/types';
+
+function run(input: string): Token[] {
+    const result = tokenize(input);
+    if ('message' in result) {
+        throw new Error(`Unexpected tokenization error: ${result.message}`);
+    }
+    return result;
+}
+
+describe('tokenize', () => {
+    describe('simple inputs', () => {
+        it('should return an empty array for an empty query', () => {
+            expect(run('')).toEqual([]);
+        });
+
+        it('should return an empty array for whitespace only', () => {
+            expect(run('   \t\n  ')).toEqual([]);
+        });
+
+        it('should tokenize a single identifier', () => {
+            const tokens = run('_name');
+            expect(tokens).toHaveLength(1);
+            expect(tokens[0]).toMatchObject({
+                type: 'identifier',
+                value: '_name',
+                position: { start: 0, end: 5 },
+            });
+        });
+
+        it('should tokenize dotted field paths as one identifier', () => {
+            const tokens = run('data.myField');
+            expect(tokens).toHaveLength(1);
+            expect(tokens[0].value).toBe('data.myField');
+        });
+
+        it('should tokenize wildcard and at-prefix identifiers', () => {
+            expect(run('*')[0].value).toBe('*');
+            expect(run('@geoPoint')[0].value).toBe('@geoPoint');
+        });
+    });
+
+    describe('keywords', () => {
+        it('should recognize keywords case-insensitively', () => {
+            for (const kw of ['AND', 'and', 'And', 'OR', 'NOT', 'LIKE', 'IN', 'ASC', 'DESC', 'ORDER', 'BY', 'COLLATE']) {
+                const tokens = run(kw);
+                expect(tokens[0].type).toBe('keyword');
+                expect(tokens[0].value).toBe(kw.toUpperCase());
+            }
+        });
+
+        it('should not confuse a keyword-like identifier prefix with a keyword', () => {
+            const tokens = run('AND_field');
+            expect(tokens).toHaveLength(1);
+            expect(tokens[0].type).toBe('identifier');
+            expect(tokens[0].value).toBe('AND_field');
+        });
+    });
+
+    describe('strings', () => {
+        it('should tokenize a single-quoted string', () => {
+            const tokens = run("'hello'");
+            expect(tokens[0]).toMatchObject({
+                type: 'string',
+                value: 'hello',
+                position: { start: 0, end: 7 },
+            });
+        });
+
+        it('should tokenize a double-quoted string', () => {
+            const tokens = run('"hello"');
+            expect(tokens[0]).toMatchObject({ type: 'string', value: 'hello' });
+        });
+
+        it('should allow spaces and special chars inside strings', () => {
+            const tokens = run("'a b, c (d)'");
+            expect(tokens[0].value).toBe('a b, c (d)');
+        });
+
+        it('should report an unterminated string', () => {
+            const result = tokenize("'no end");
+            expect(result).toMatchObject({
+                message: expect.stringContaining('Unterminated string'),
+                position: { start: 0, end: 7 },
+            });
+        });
+    });
+
+    describe('numbers', () => {
+        it('should tokenize integers', () => {
+            expect(run('42')[0]).toMatchObject({ type: 'number', value: '42' });
+        });
+
+        it('should tokenize negative numbers', () => {
+            expect(run('-3.14')[0]).toMatchObject({ type: 'number', value: '-3.14' });
+        });
+
+        it('should tokenize positive-signed numbers', () => {
+            expect(run('+10')[0]).toMatchObject({ type: 'number', value: '+10' });
+        });
+
+        it('should tokenize decimals', () => {
+            expect(run('0.5')[0]).toMatchObject({ type: 'number', value: '0.5' });
+        });
+
+        it('should report a malformed number', () => {
+            const result = tokenize('1.');
+            expect(result).toMatchObject({
+                message: expect.stringContaining('Malformed number'),
+            });
+        });
+    });
+
+    describe('operators and punctuation', () => {
+        it('should tokenize comparison operators', () => {
+            for (const op of ['=', '!=', '>', '>=', '<', '<=']) {
+                const tokens = run(op);
+                expect(tokens[0]).toMatchObject({ type: 'operator', value: op });
+            }
+        });
+
+        it('should tokenize parentheses and commas as distinct types', () => {
+            const tokens = run('(a,b)');
+            expect(tokens.map(t => t.type)).toEqual([
+                'lparen',
+                'identifier',
+                'comma',
+                'identifier',
+                'rparen',
+            ]);
+        });
+    });
+
+    describe('errors', () => {
+        it('should report an illegal character', () => {
+            const result = tokenize('a ~ b');
+            expect(result).toMatchObject({
+                message: expect.stringContaining("Invalid character '~'"),
+                position: { start: 2, end: 3 },
+            });
+        });
+    });
+
+    describe('position tracking', () => {
+        it('should report accurate offsets for all tokens', () => {
+            const tokens = run("_name = 'x'");
+            expect(tokens[0].position).toEqual({ start: 0, end: 5 });
+            expect(tokens[1].position).toEqual({ start: 6, end: 7 });
+            expect(tokens[2].position).toEqual({ start: 8, end: 11 });
+        });
+    });
+
+    describe('realistic queries', () => {
+        it('should tokenize a compare with AND', () => {
+            const tokens = run("_name = 'a' AND _path LIKE '/foo*'");
+            expect(tokens.map(t => t.type)).toEqual([
+                'identifier',
+                'operator',
+                'string',
+                'keyword',
+                'identifier',
+                'keyword',
+                'string',
+            ]);
+        });
+
+        it('should tokenize an ORDER BY clause', () => {
+            const tokens = run('ORDER BY _ts DESC');
+            expect(tokens.map(t => t.value)).toEqual(['ORDER', 'BY', '_ts', 'DESC']);
+        });
+    });
+});

--- a/src/test/assets/js/lib/noql/validator.test.ts
+++ b/src/test/assets/js/lib/noql/validator.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+import { validate } from '../../../../../main/resources/assets/js/lib/noql/validator';
+
+describe('validate', () => {
+    describe('valid queries', () => {
+        it('should accept an empty query', () => {
+            expect(validate('')).toBeNull();
+        });
+
+        it('should accept whitespace only', () => {
+            expect(validate('   ')).toBeNull();
+        });
+
+        it('should accept a simple compare', () => {
+            expect(validate("_name = 'x'")).toBeNull();
+        });
+
+        it('should accept all comparison operators', () => {
+            for (const op of ['=', '!=', '>', '>=', '<', '<=']) {
+                expect(validate(`score ${op} 5`)).toBeNull();
+            }
+        });
+
+        it('should accept AND / OR with precedence', () => {
+            expect(validate("a = '1' AND b = '2' OR c = '3'")).toBeNull();
+        });
+
+        it('should accept NOT prefix', () => {
+            expect(validate("NOT (a = '1')")).toBeNull();
+        });
+
+        it('should accept nested parentheses', () => {
+            expect(validate("((a = '1') AND (b = '2'))")).toBeNull();
+        });
+
+        it('should accept LIKE and NOT LIKE', () => {
+            expect(validate("_name LIKE '*x*'")).toBeNull();
+            expect(validate("_name NOT LIKE '*x*'")).toBeNull();
+        });
+
+        it('should accept IN and NOT IN', () => {
+            expect(validate("_name IN ('a', 'b', 'c')")).toBeNull();
+            expect(validate("_name NOT IN ('a', 'b')")).toBeNull();
+        });
+
+        it('should accept ORDER BY with direction', () => {
+            expect(validate('ORDER BY _ts DESC')).toBeNull();
+            expect(validate('ORDER BY foo ASC, bar DESC')).toBeNull();
+        });
+
+        it('should accept ORDER BY with score()', () => {
+            expect(validate('ORDER BY score() DESC')).toBeNull();
+        });
+
+        it('should accept ORDER BY with geoDistance()', () => {
+            expect(validate("ORDER BY geoDistance(location, '59,10') ASC")).toBeNull();
+        });
+
+        it('should accept ORDER BY with COLLATE', () => {
+            expect(validate("ORDER BY _name ASC COLLATE 'no'")).toBeNull();
+        });
+
+        it('should accept a compare plus ORDER BY', () => {
+            expect(validate("_name LIKE '*x*' ORDER BY _ts DESC")).toBeNull();
+        });
+
+        it('should accept a value function call', () => {
+            expect(validate("timestamp > instant('2024-01-01T00:00:00Z')")).toBeNull();
+        });
+
+        it('should accept a constraint function call', () => {
+            expect(validate("fulltext('title,body', 'hello', 'AND')")).toBeNull();
+        });
+
+        it('should accept a constraint function with min and max args', () => {
+            expect(validate("pathMatch('_path', '/a/b')")).toBeNull();
+            expect(validate("range('age', 18, 65, 'true', 'false')")).toBeNull();
+        });
+    });
+
+    describe('tokenization errors bubble up', () => {
+        it('should report unterminated strings', () => {
+            const err = validate("_name = 'x");
+            expect(err?.message).toContain('Unterminated string');
+        });
+
+        it('should report illegal characters', () => {
+            const err = validate('a ~ b');
+            expect(err?.message).toContain("Invalid character '~'");
+        });
+    });
+
+    describe('parse errors', () => {
+        it('should report a missing closing paren', () => {
+            const err = validate("(_name = 'x'");
+            expect(err?.message).toMatch(/Expected '\)'|close/i);
+        });
+
+        it('should report an unexpected bare keyword', () => {
+            const err = validate('BY foo');
+            expect(err).not.toBeNull();
+        });
+
+        it('should report a trailing operator', () => {
+            const err = validate('_name =');
+            expect(err).not.toBeNull();
+        });
+
+        it('should report a dangling AND', () => {
+            const err = validate("_name = 'a' AND");
+            expect(err).not.toBeNull();
+        });
+
+        it('should report missing ORDER keyword', () => {
+            const err = validate("_name = 'x' BY _ts");
+            expect(err).not.toBeNull();
+        });
+
+        it('should report BY without ORDER', () => {
+            const err = validate('BY');
+            expect(err).not.toBeNull();
+        });
+
+        it('should report NOT without LIKE or IN after field', () => {
+            const err = validate('_name NOT = 5');
+            expect(err).not.toBeNull();
+        });
+    });
+
+    describe('semantic errors', () => {
+        it('should suggest fulltext for a typo', () => {
+            const err = validate("fultext('title', 'foo')");
+            expect(err?.message).toContain("Unknown function 'fultext'");
+            expect(err?.suggestion).toBe("Did you mean 'fulltext'?");
+        });
+
+        it('should suggest score for a typo in ORDER BY', () => {
+            const err = validate('ORDER BY scoor() DESC');
+            expect(err?.message).toContain("Unknown function 'scoor'");
+            expect(err?.suggestion).toBe("Did you mean 'score'?");
+        });
+
+        it('should report wrong arity for a constraint function', () => {
+            const err = validate("fulltext('a', 'b', 'c', 'd', 'e')");
+            expect(err?.message).toMatch(/fulltext.*2.{1,3}4.*5/);
+        });
+
+        it('should report wrong arity for a value function', () => {
+            const err = validate("timestamp > instant('a', 'b')");
+            expect(err?.message).toMatch(/instant.*1.*2/);
+        });
+
+        it('should reject a sort function used as a value', () => {
+            const _err = validate('score > 0.5');
+            // score is an identifier here — fine. But `x > score()` should fail as sort in value context.
+            expect(validate('x > score()')?.message).toMatch(/score.*ORDER BY/);
+        });
+
+        it('should reject a value function used as a constraint', () => {
+            const err = validate("instant('2024-01-01')");
+            expect(err?.message).toMatch(/instant.*value function/i);
+        });
+
+        it('should accept geoDistance only in ORDER BY', () => {
+            expect(validate("ORDER BY geoDistance(loc, '1,2') ASC")).toBeNull();
+            expect(validate("x = geoDistance(loc, '1,2')")?.message).toMatch(/geoDistance.*ORDER BY/);
+        });
+    });
+
+    describe('position and suggestion payload', () => {
+        it('should include a position on unknown function', () => {
+            const err = validate("fultext('a', 'b')");
+            expect(err?.position).toMatchObject({ start: 0, end: 7 });
+        });
+    });
+});


### PR DESCRIPTION
Adds a zero-dependency NoQL tokenizer and recursive-descent parser/validator under `lib/noql/`. The validator runs in the browser as the user types (300ms debounce), surfacing parse errors, semantic errors (unknown functions, wrong arities, context misuse), and "Did you mean?" suggestions via Levenshtein distance — all before any server round-trip. Validation is advisory; submit stays enabled.

This is Phase 1 of the search-editor upgrade. Phase 2 (#44) will replace the plain `<input>` with a CodeMirror editor that reuses this validator's `validate()` API and position offsets for inline lint markers.

Closes #43

<sub>*Drafted with AI assistance*</sub>
