### PR TITLE
fix: use template literal for startup log to work around GraalJS logger bug

### DIFF
--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -2,4 +2,4 @@ import { joinValues, toTag } from './lib/text';
 
 const tags = [toTag('name', app.name), toTag('version', app.version)];
 
-log.info('Data Kit started: %s', joinValues(tags));
+log.info(`Data Kit started: ${joinValues(tags)}`);


### PR DESCRIPTION
Replaced the `%s` format placeholder in the startup log with a template literal so the message renders correctly under XP's GraalJS engine.

**Root cause**: `GraalScriptLogger.format()` in XP has an off-by-one in `arguments.length == 1` (should be `== 0`). With exactly one format arg it short-circuits before calling `String.format`, so `%s` leaks through literally. The fix side-steps the placeholder path entirely.

<sub>*Drafted with AI assistance*</sub>
