### PR TITLE
refactor: migrate XP descriptors to .yaml with required kind field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,10 +38,11 @@ pnpm test           # vitest only
 
 ## XP 8 Descriptors
 
-XP 8 replaced XML descriptors with YAML across the board. All descriptors in this project use `.yml` — **never create `.xml` descriptors**. This applies to:
+XP 8 replaced XML descriptors with YAML across the board. All descriptors in this project use `.yaml` — **never create `.xml` descriptors**. Every descriptor must declare a `kind:` field. This applies to:
 
-- API descriptors (`apis/*/*.yml`)
-- Admin tool descriptors (`admin/tools/main/main.yml`)
+- Application descriptor (`application.yaml`) — requires `kind: "Application"`
+- API descriptors (`apis/*/*.yaml`) — require `kind: "API"` and a `title`
+- Admin tool descriptors (`admin/tools/main/main.yaml`) — require `kind: "AdminTool"` and `title` (not `displayName`)
 - Content types, mixins, x-data, etc.
 
 There is little official documentation on this yet, so don't rely on older XP docs that show XML examples.

--- a/src/main/resources/admin/tools/main/main.ts
+++ b/src/main/resources/admin/tools/main/main.ts
@@ -20,6 +20,7 @@ type DataKitConfig = {
         exports: string;
         tasks: string;
         events: string;
+        audit: string;
     };
     launcherUri: string;
     user: {
@@ -47,6 +48,7 @@ function buildConfig(): DataKitConfig {
             exports: apiUrl({ api: 'exports', type: 'server' }),
             tasks: apiUrl({ api: 'tasks', type: 'server' }),
             events: apiUrl({ api: 'events', type: 'websocket' }),
+            audit: apiUrl({ api: 'audit', type: 'server' }),
         },
         launcherUri: extensionUrl({
             application: 'com.enonic.xp.app.main',

--- a/src/main/resources/admin/tools/main/main.yaml
+++ b/src/main/resources/admin/tools/main/main.yaml
@@ -1,4 +1,5 @@
-displayName:
+kind: "AdminTool"
+title:
   text: "Data Kit"
   i18n: "admin.tool.main.displayName"
 description:

--- a/src/main/resources/apis/binary/binary.yaml
+++ b/src/main/resources/apis/binary/binary.yaml
@@ -1,0 +1,4 @@
+kind: "API"
+title: "Binary API"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/apis/branches/branches.yaml
+++ b/src/main/resources/apis/branches/branches.yaml
@@ -1,0 +1,4 @@
+kind: "API"
+title: "Branches API"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/apis/dumps/dumps.yaml
+++ b/src/main/resources/apis/dumps/dumps.yaml
@@ -1,2 +1,4 @@
+kind: "API"
+title: "Dumps API"
 allow:
   - "role:system.admin"

--- a/src/main/resources/apis/events/events.yaml
+++ b/src/main/resources/apis/events/events.yaml
@@ -1,0 +1,4 @@
+kind: "API"
+title: "Events API"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/apis/events/events.yml
+++ b/src/main/resources/apis/events/events.yml
@@ -1,2 +1,0 @@
-allow:
-  - "role:system.admin"

--- a/src/main/resources/apis/exports/exports.yaml
+++ b/src/main/resources/apis/exports/exports.yaml
@@ -1,0 +1,4 @@
+kind: "API"
+title: "Exports API"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/apis/exports/exports.yml
+++ b/src/main/resources/apis/exports/exports.yml
@@ -1,2 +1,0 @@
-allow:
-  - "role:system.admin"

--- a/src/main/resources/apis/nodes/nodes.yaml
+++ b/src/main/resources/apis/nodes/nodes.yaml
@@ -1,2 +1,4 @@
+kind: "API"
+title: "Nodes API"
 allow:
   - "role:system.admin"

--- a/src/main/resources/apis/nodes/nodes.yml
+++ b/src/main/resources/apis/nodes/nodes.yml
@@ -1,2 +1,0 @@
-allow:
-  - "role:system.admin"

--- a/src/main/resources/apis/repositories/repositories.yaml
+++ b/src/main/resources/apis/repositories/repositories.yaml
@@ -1,0 +1,4 @@
+kind: "API"
+title: "Repositories API"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/apis/repositories/repositories.yml
+++ b/src/main/resources/apis/repositories/repositories.yml
@@ -1,2 +1,0 @@
-allow:
-  - "role:system.admin"

--- a/src/main/resources/apis/search/search.yaml
+++ b/src/main/resources/apis/search/search.yaml
@@ -1,0 +1,4 @@
+kind: "API"
+title: "Search API"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/apis/search/search.yml
+++ b/src/main/resources/apis/search/search.yml
@@ -1,2 +1,0 @@
-allow:
-  - "role:system.admin"

--- a/src/main/resources/apis/snapshots/snapshots.yaml
+++ b/src/main/resources/apis/snapshots/snapshots.yaml
@@ -1,0 +1,4 @@
+kind: "API"
+title: "Snapshots API"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/apis/snapshots/snapshots.yml
+++ b/src/main/resources/apis/snapshots/snapshots.yml
@@ -1,2 +1,0 @@
-allow:
-  - "role:system.admin"

--- a/src/main/resources/apis/system/system.yaml
+++ b/src/main/resources/apis/system/system.yaml
@@ -1,0 +1,4 @@
+kind: "API"
+title: "System API"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/apis/system/system.yml
+++ b/src/main/resources/apis/system/system.yml
@@ -1,2 +1,0 @@
-allow:
-  - "role:system.admin"

--- a/src/main/resources/apis/tasks/tasks.yaml
+++ b/src/main/resources/apis/tasks/tasks.yaml
@@ -1,2 +1,4 @@
+kind: "API"
+title: "Tasks API"
 allow:
   - "role:system.admin"

--- a/src/main/resources/apis/tasks/tasks.yml
+++ b/src/main/resources/apis/tasks/tasks.yml
@@ -1,2 +1,0 @@
-allow:
-  - "role:system.admin"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,1 +1,2 @@
+kind: "Application"
 description: "XP data management application for admins"


### PR DESCRIPTION
Renamed every XP descriptor from `.yml` to `.yaml` and added the `kind:` field required by XP 8 (`Application`, `AdminTool`, `API`). On the AdminTool descriptor, `displayName:` becomes `title:`. Every API descriptor now carries a `title:` as well.

Also registers the `audit` API URL in `main.ts` `buildConfig()` — it was missing since #20 — and updates `CLAUDE.md` to match the new descriptor shape.

<sub>*Drafted with AI assistance*</sub>
