### PR TITLE
feat: implement node version management #14

### DIFF
--- a/src/main/resources/admin/tools/main/main.ts
+++ b/src/main/resources/admin/tools/main/main.ts
@@ -21,6 +21,7 @@ type DataKitConfig = {
         tasks: string;
         events: string;
         audit: string;
+        versions: string;
     };
     launcherUri: string;
     user: {
@@ -49,6 +50,7 @@ function buildConfig(): DataKitConfig {
             tasks: apiUrl({ api: 'tasks', type: 'server' }),
             events: apiUrl({ api: 'events', type: 'websocket' }),
             audit: apiUrl({ api: 'audit', type: 'server' }),
+            versions: apiUrl({ api: 'versions', type: 'server' }),
         },
         launcherUri: extensionUrl({
             application: 'com.enonic.xp.app.main',

--- a/src/main/resources/admin/tools/main/main.yaml
+++ b/src/main/resources/admin/tools/main/main.yaml
@@ -22,3 +22,5 @@ apis:
   - "exports"
   - "tasks"
   - "events"
+  - "audit"
+  - "versions"

--- a/src/main/resources/apis/versions/versions.ts
+++ b/src/main/resources/apis/versions/versions.ts
@@ -1,0 +1,161 @@
+import type { Request, Response } from '@enonic-types/core';
+import type { NodeCommit, NodeVersion, RepoConnection } from '@enonic-types/lib-node';
+import { connect } from '/lib/xp/node';
+import { errorResponse, getParam, jsonResponse, requireAdmin } from '../../lib/api';
+
+//
+// * Types
+//
+
+type NodeCommitDto = {
+    id: string;
+    message: string;
+    committer: string;
+    timestamp: string;
+};
+
+type NodeVersionDto = NodeVersion & {
+    commit?: NodeCommitDto | null;
+};
+
+type VersionsResult = {
+    total: number;
+    count: number;
+    cursor: string | null;
+    activeVersionId: string | null;
+    hits: NodeVersionDto[];
+};
+
+type SetActiveBody = {
+    repoId?: string;
+    branch?: string;
+    key?: string;
+    versionId?: string;
+};
+
+// ? setActiveVersion exists at runtime in XP 8 but is not in @enonic-types/lib-node@8.0.0-A3 yet.
+//   Remove this shim when the types catch up.
+type RepoConnectionWithSetActive = RepoConnection & {
+    setActiveVersion: (params: { key: string; versionId: string }) => boolean;
+};
+
+const DEFAULT_COUNT = 25;
+
+//
+// * Helpers
+//
+
+function resolveCommit(
+    repo: RepoConnection,
+    commitId: string,
+    cache: Record<string, NodeCommitDto | null>,
+): NodeCommitDto | null {
+    if (cache[commitId] !== undefined) return cache[commitId];
+
+    let resolved: NodeCommitDto | null = null;
+    try {
+        const commit: NodeCommit | null = repo.getCommit({ id: commitId });
+        if (commit != null) {
+            resolved = {
+                id: commit.id,
+                message: commit.message,
+                committer: commit.committer,
+                timestamp: commit.timestamp,
+            };
+        }
+    } catch (_e) {
+        resolved = null;
+    }
+    cache[commitId] = resolved;
+    return resolved;
+}
+
+//
+// * GET — list versions
+//
+
+export function get(req: Request): Response {
+    const forbidden = requireAdmin();
+    if (forbidden != null) return forbidden;
+
+    const repoId = getParam(req, 'repoId');
+    if (repoId == null) return errorResponse(400, 'repoId is required', 'VALIDATION_ERROR');
+
+    const branch = getParam(req, 'branch');
+    if (branch == null) return errorResponse(400, 'branch is required', 'VALIDATION_ERROR');
+
+    const key = getParam(req, 'key');
+    if (key == null) return errorResponse(400, 'key is required', 'VALIDATION_ERROR');
+
+    const cursor = getParam(req, 'cursor');
+    const countRaw = getParam(req, 'count');
+    const parsedCount = countRaw != null ? Number.parseInt(countRaw, 10) : Number.NaN;
+    const count = Number.isFinite(parsedCount) && parsedCount > 0 ? parsedCount : DEFAULT_COUNT;
+
+    try {
+        const repo = connect({ repoId, branch });
+
+        const node = repo.get(key);
+        if (node == null) return errorResponse(404, `Node '${key}' not found`, 'NOT_FOUND');
+
+        const result = repo.getVersions({
+            key,
+            cursor: cursor ?? null,
+            count,
+        });
+
+        const active = repo.getActiveVersion({ key });
+
+        const commitCache: Record<string, NodeCommitDto | null> = {};
+        const hits: NodeVersionDto[] = result.hits.map(v => {
+            if (v.commitId == null) return v;
+            return { ...v, commit: resolveCommit(repo, v.commitId, commitCache) };
+        });
+
+        return jsonResponse({
+            total: result.total,
+            count: result.count,
+            cursor: result.cursor ?? null,
+            activeVersionId: active?.versionId ?? null,
+            hits,
+        } satisfies VersionsResult);
+    } catch (_e) {
+        return errorResponse(500, 'Failed to list versions', 'INTERNAL_ERROR');
+    }
+}
+
+//
+// * PUT — set active version
+//
+
+export function put(req: Request): Response {
+    const forbidden = requireAdmin();
+    if (forbidden != null) return forbidden;
+
+    let body: SetActiveBody;
+    try {
+        body = req.body != null ? (JSON.parse(req.body as string) as SetActiveBody) : {};
+    } catch (_e) {
+        return errorResponse(400, 'Invalid JSON body', 'VALIDATION_ERROR');
+    }
+
+    const { repoId, branch, key, versionId } = body;
+    if (repoId == null) return errorResponse(400, 'repoId is required', 'VALIDATION_ERROR');
+    if (branch == null) return errorResponse(400, 'branch is required', 'VALIDATION_ERROR');
+    if (key == null) return errorResponse(400, 'key is required', 'VALIDATION_ERROR');
+    if (versionId == null) return errorResponse(400, 'versionId is required', 'VALIDATION_ERROR');
+
+    try {
+        const repo = connect({ repoId, branch }) as RepoConnectionWithSetActive;
+
+        const node = repo.get(key);
+        if (node == null) return errorResponse(404, `Node '${key}' not found`, 'NOT_FOUND');
+
+        const success = repo.setActiveVersion({ key, versionId });
+        if (!success) return errorResponse(404, `Version '${versionId}' not found`, 'NOT_FOUND');
+
+        return jsonResponse({ key, versionId, active: true });
+    } catch (_e) {
+        return errorResponse(500, 'Failed to set active version', 'INTERNAL_ERROR');
+    }
+}

--- a/src/main/resources/apis/versions/versions.yaml
+++ b/src/main/resources/apis/versions/versions.yaml
@@ -1,0 +1,4 @@
+kind: "API"
+title: "Node Versions API"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/assets/js/components/node-detail-panel.tsx
+++ b/src/main/resources/assets/js/components/node-detail-panel.tsx
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
-import { ArrowRightLeft, Copy, Download, Ellipsis, Pencil, Plus, Send, Shield, Table2, Trash2, X } from 'lucide-react';
-import { type ReactElement, useEffect, useMemo, useState } from 'react';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { ArrowRightLeft, Braces, Copy, Download, Ellipsis, History, Info, Pencil, Plus, Send, Shield, Table2, Trash2, X } from 'lucide-react';
+import { type ReactElement, type MouseEvent as ReactMouseEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { createHighlighterCore } from 'shiki/core';
 import langJson from 'shiki/dist/langs/json.mjs';
 import themeGithubDarkDefault from 'shiki/dist/themes/github-dark-default.mjs';
@@ -21,7 +21,9 @@ import {
     usePushNode,
     useRenameNode,
 } from '../lib/api/nodes';
+import { versionsInfiniteQueryOptions } from '../lib/api/versions';
 import { cn } from '../lib/utils';
+import { NodeVersionsTab } from './node-versions-tab';
 import { useTheme } from './theme-provider';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
@@ -219,10 +221,10 @@ const PropertiesTab = ({ node, repoId, branch, onNavigateToNode }: PropertiesTab
                             <TableCell>
                                 <Badge variant="secondary">{prop.type}</Badge>
                             </TableCell>
-                            <TableCell className="max-w-[300px] font-mono text-sm">
+                            <TableCell className="break-all font-mono text-sm">
                                 {prop.type === 'BinaryReference' ? (
-                                    <span className="flex items-center gap-1.5">
-                                        <span className="truncate">{prop.value}</span>
+                                    <span className="flex items-start gap-1.5">
+                                        <span className="break-all">{prop.value}</span>
                                         <Tooltip>
                                             <TooltipTrigger asChild>
                                                 <a
@@ -252,13 +254,13 @@ const PropertiesTab = ({ node, repoId, branch, onNavigateToNode }: PropertiesTab
                                 ) : prop.type === 'Reference' ? (
                                     <button
                                         type="button"
-                                        className="truncate text-left underline decoration-muted-foreground/50 underline-offset-2 hover:decoration-foreground"
+                                        className="break-all text-left underline decoration-muted-foreground/50 underline-offset-2 hover:decoration-foreground"
                                         onClick={() => onNavigateToNode?.(prop.value)}
                                     >
                                         {prop.value}
                                     </button>
                                 ) : (
-                                    <span className="truncate">{prop.value}</span>
+                                    <span className="break-all">{prop.value}</span>
                                 )}
                             </TableCell>
                         </TableRow>
@@ -295,7 +297,7 @@ const MetadataTab = ({ node }: { node: NodeDetail }): ReactElement => {
                                 <TableCell className="font-medium">
                                     {key}
                                 </TableCell>
-                                <TableCell className="font-mono text-sm">
+                                <TableCell className="break-all font-mono text-sm">
                                     {key === '_nodeType' && value != null ? (
                                         <Badge variant="secondary">
                                             {value}
@@ -872,6 +874,14 @@ const NodeDetailContent = ({
     onNavigateToNode?: (nodeId: string) => void;
 }): ReactElement => {
     const { data: node, isLoading, error } = useQuery(nodeDetailQueryOptions(params));
+    const versionsInfinite = useInfiniteQuery(
+        versionsInfiniteQueryOptions({
+            repoId: params.repoId,
+            branch: params.branch,
+            key: params.key,
+        }),
+    );
+    const versionsTotal = versionsInfinite.data?.pages[0]?.total;
 
     if (isLoading) {
         return (
@@ -934,10 +944,31 @@ const NodeDetailContent = ({
             {/* Tabs */}
             <Tabs defaultValue="properties" className="flex flex-1 flex-col overflow-hidden">
                 <TabsList className="mx-4 mt-2 w-auto">
-                    <TabsTrigger value="properties">Properties</TabsTrigger>
-                    <TabsTrigger value="metadata">Metadata</TabsTrigger>
-                    <TabsTrigger value="permissions">Permissions</TabsTrigger>
-                    <TabsTrigger value="json">JSON</TabsTrigger>
+                    <TabsTrigger value="properties" title="Properties" className="@[576px]:px-3 px-2">
+                        <Table2 className="size-3.5" />
+                        <span className="ml-1.5 @[576px]:inline hidden">Properties</span>
+                    </TabsTrigger>
+                    <TabsTrigger value="metadata" title="Metadata" className="@[576px]:px-3 px-2">
+                        <Info className="size-3.5" />
+                        <span className="ml-1.5 @[576px]:inline hidden">Metadata</span>
+                    </TabsTrigger>
+                    <TabsTrigger value="permissions" title="Permissions" className="@[576px]:px-3 px-2">
+                        <Shield className="size-3.5" />
+                        <span className="ml-1.5 @[576px]:inline hidden">Permissions</span>
+                    </TabsTrigger>
+                    <TabsTrigger value="versions" title="Versions" className="@[576px]:px-3 px-2">
+                        <History className="size-3.5" />
+                        <span className="ml-1.5 @[576px]:inline hidden">Versions</span>
+                        {versionsTotal != null && (
+                            <Badge variant="secondary" className="ml-1.5 @[576px]:inline-flex hidden">
+                                {versionsTotal}
+                            </Badge>
+                        )}
+                    </TabsTrigger>
+                    <TabsTrigger value="json" title="JSON" className="@[576px]:px-3 px-2">
+                        <Braces className="size-3.5" />
+                        <span className="ml-1.5 @[576px]:inline hidden">JSON</span>
+                    </TabsTrigger>
                 </TabsList>
                 <div className="flex-1 overflow-auto">
                     <TabsContent value="properties">
@@ -954,6 +985,14 @@ const NodeDetailContent = ({
                     <TabsContent value="permissions">
                         <PermissionsTab
                             permissions={node._permissions ?? []}
+                        />
+                    </TabsContent>
+                    <TabsContent value="versions">
+                        <NodeVersionsTab
+                            repoId={params.repoId}
+                            branch={params.branch}
+                            nodeKey={params.key}
+                            nodeName={node._name}
                         />
                     </TabsContent>
                     <TabsContent value="json">
@@ -973,6 +1012,31 @@ NodeDetailContent.displayName = NODE_DETAIL_CONTENT_NAME;
 
 const NODE_DETAIL_PANEL_NAME = 'NodeDetailPanel';
 
+const PANEL_WIDTH_STORAGE_KEY = 'datakit:detail-panel-width';
+const PANEL_MIN_WIDTH = 320;
+const PANEL_MAX_WIDTH = 900;
+const PANEL_DEFAULT_WIDTH = 620;
+
+function readStoredWidth(): number {
+    try {
+        const raw = window.localStorage.getItem(PANEL_WIDTH_STORAGE_KEY);
+        if (raw == null) return PANEL_DEFAULT_WIDTH;
+        const parsed = Number.parseInt(raw, 10);
+        if (!Number.isFinite(parsed)) return PANEL_DEFAULT_WIDTH;
+        return Math.min(PANEL_MAX_WIDTH, Math.max(PANEL_MIN_WIDTH, parsed));
+    } catch {
+        return PANEL_DEFAULT_WIDTH;
+    }
+}
+
+function writeStoredWidth(width: number): void {
+    try {
+        window.localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(width));
+    } catch {
+        // ignore quota / disabled storage
+    }
+}
+
 export const NodeDetailPanel = ({
     nodeId,
     repoId,
@@ -981,11 +1045,68 @@ export const NodeDetailPanel = ({
     onNodeMutated,
     onNavigateToNode,
 }: NodeDetailPanelProps): ReactElement => {
+    const [width, setWidth] = useState<number>(readStoredWidth);
+    const dragStateRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
+    useEffect(() => {
+        const handleMove = (e: MouseEvent) => {
+            const state = dragStateRef.current;
+            if (state == null) return;
+            // Panel is anchored to the right edge — dragging left increases width
+            const delta = state.startX - e.clientX;
+            const next = Math.min(
+                PANEL_MAX_WIDTH,
+                Math.max(PANEL_MIN_WIDTH, state.startWidth + delta),
+            );
+            setWidth(next);
+        };
+
+        const handleUp = () => {
+            if (dragStateRef.current == null) return;
+            dragStateRef.current = null;
+            document.body.style.cursor = '';
+            document.body.style.userSelect = '';
+        };
+
+        window.addEventListener('mousemove', handleMove);
+        window.addEventListener('mouseup', handleUp);
+        return () => {
+            window.removeEventListener('mousemove', handleMove);
+            window.removeEventListener('mouseup', handleUp);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (dragStateRef.current == null) writeStoredWidth(width);
+    }, [width]);
+
+    const handleDragStart = (e: ReactMouseEvent<HTMLButtonElement>) => {
+        dragStateRef.current = { startX: e.clientX, startWidth: width };
+        document.body.style.cursor = 'col-resize';
+        document.body.style.userSelect = 'none';
+    };
+
+    const handleDoubleClick = () => {
+        setWidth(PANEL_DEFAULT_WIDTH);
+    };
+
     return (
         <div
             data-component={NODE_DETAIL_PANEL_NAME}
-            className="flex w-[400px] shrink-0 flex-col border-border border-l bg-card"
+            style={{ width: `${width}px` }}
+            className="@container relative flex shrink-0 flex-col border-border border-l bg-card"
         >
+            <button
+                type="button"
+                aria-label="Resize detail panel"
+                title="Drag to resize, double-click to reset"
+                onMouseDown={handleDragStart}
+                onDoubleClick={handleDoubleClick}
+                className={cn(
+                    'absolute top-0 left-0 z-10 h-full w-1 -translate-x-1/2 cursor-col-resize',
+                    'bg-transparent transition-colors hover:bg-primary/30 focus-visible:bg-primary/30 focus-visible:outline-none',
+                )}
+            />
             <NodeDetailContent
                 params={{ repoId, branch, key: nodeId }}
                 onClose={onClose}

--- a/src/main/resources/assets/js/components/node-versions-tab.tsx
+++ b/src/main/resources/assets/js/components/node-versions-tab.tsx
@@ -1,0 +1,321 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { ChevronRight, Copy, GitCommit, History, RotateCcw } from 'lucide-react';
+import { type MouseEvent, type ReactElement, type ReactNode, useMemo, useState } from 'react';
+import {
+    type NodeVersionEntry,
+    useSetActiveVersion,
+    versionsInfiniteQueryOptions,
+} from '../lib/api/versions';
+import { cn } from '../lib/utils';
+import { Badge } from './ui/badge';
+import { Button } from './ui/button';
+import { ConfirmDialog } from './ui/confirm-dialog';
+import { EmptyState } from './ui/empty-state';
+import { Skeleton } from './ui/skeleton';
+import { toast } from './ui/sonner';
+
+//
+// * Types
+//
+
+export type NodeVersionsTabProps = {
+    repoId: string;
+    branch: string;
+    nodeKey: string;
+    nodeName: string;
+};
+
+const NODE_VERSIONS_TAB_NAME = 'NodeVersionsTab';
+
+const SHORT_ID_LENGTH = 6;
+
+//
+// * Helpers
+//
+
+function shortId(id: string): string {
+    return id.slice(0, SHORT_ID_LENGTH);
+}
+
+function formatTime(ts: string): string {
+    try {
+        return new Date(ts).toLocaleTimeString([], {
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+        });
+    } catch {
+        return ts;
+    }
+}
+
+function formatFullTimestamp(ts: string): string {
+    try {
+        return new Date(ts).toLocaleString();
+    } catch {
+        return ts;
+    }
+}
+
+//
+// * Sub-components
+//
+
+type VersionDetailRowProps = {
+    label: string;
+    children: ReactNode;
+};
+
+const VERSION_DETAIL_ROW_NAME = 'VersionDetailRow';
+
+const VersionDetailRow = ({ label, children }: VersionDetailRowProps): ReactElement => (
+    <div data-component={VERSION_DETAIL_ROW_NAME} className="flex items-center gap-2">
+        <span className="w-20 shrink-0 text-muted-foreground text-xs">{label}</span>
+        <div className="flex min-w-0 flex-1 items-center gap-1.5">{children}</div>
+    </div>
+);
+
+VersionDetailRow.displayName = VERSION_DETAIL_ROW_NAME;
+
+type CopyIconButtonProps = {
+    value: string;
+    label: string;
+    toastText: string;
+};
+
+const COPY_ICON_BUTTON_NAME = 'CopyIconButton';
+
+const CopyIconButton = ({ value, label, toastText }: CopyIconButtonProps): ReactElement => {
+    const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+        navigator.clipboard.writeText(value);
+        toast.success(toastText);
+    };
+
+    return (
+        <button
+            data-component={COPY_ICON_BUTTON_NAME}
+            type="button"
+            aria-label={label}
+            title={label}
+            onClick={handleClick}
+            className={cn(
+                'inline-flex size-5 shrink-0 items-center justify-center rounded-sm',
+                'text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground',
+            )}
+        >
+            <Copy className="size-3" />
+        </button>
+    );
+};
+
+CopyIconButton.displayName = COPY_ICON_BUTTON_NAME;
+
+//
+// * Main component
+//
+
+export const NodeVersionsTab = ({
+    repoId,
+    branch,
+    nodeKey,
+    nodeName,
+}: NodeVersionsTabProps): ReactElement => {
+    const [expanded, setExpanded] = useState<Set<string>>(new Set());
+    const [pendingVersion, setPendingVersion] = useState<NodeVersionEntry | undefined>(undefined);
+
+    const {
+        data,
+        isLoading,
+        error,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+    } = useInfiniteQuery(versionsInfiniteQueryOptions({ repoId, branch, key: nodeKey }));
+
+    const setActiveMutation = useSetActiveVersion();
+
+    const versions = useMemo<NodeVersionEntry[]>(
+        () => data?.pages.flatMap(p => p.hits) ?? [],
+        [data],
+    );
+    const activeVersionId = data?.pages[0]?.activeVersionId ?? null;
+
+    const toggleExpand = (versionId: string) => {
+        setExpanded(prev => {
+            const next = new Set(prev);
+            if (next.has(versionId)) next.delete(versionId);
+            else next.add(versionId);
+            return next;
+        });
+    };
+
+    const handleSetActive = () => {
+        if (pendingVersion == null) return;
+        setActiveMutation.mutate(
+            { repoId, branch, key: nodeKey, versionId: pendingVersion.versionId },
+            {
+                onSuccess: () => {
+                    toast.success('Version set as active');
+                    setPendingVersion(undefined);
+                },
+                onError: () => {
+                    toast.error('Failed to set active version');
+                },
+            },
+        );
+    };
+
+    if (isLoading) {
+        return (
+            <div data-component={NODE_VERSIONS_TAB_NAME} className="space-y-1 p-2">
+                {Array.from({ length: 6 }).map((_, i) => (
+                    // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
+                    <Skeleton key={i} className="h-8 w-full" />
+                ))}
+            </div>
+        );
+    }
+
+    if (error != null) {
+        return (
+            <div
+                data-component={NODE_VERSIONS_TAB_NAME}
+                className="py-8 text-center text-destructive text-sm"
+            >
+                Failed to load versions.
+            </div>
+        );
+    }
+
+    if (versions.length === 0) {
+        return (
+            <div data-component={NODE_VERSIONS_TAB_NAME}>
+                <EmptyState
+                    icon={History}
+                    title="No version history"
+                    description="This node has no stored versions yet."
+                />
+            </div>
+        );
+    }
+
+    return (
+        <div data-component={NODE_VERSIONS_TAB_NAME} className="flex flex-col">
+            <ul role="list" className="divide-y divide-border">
+                {versions.map(v => {
+                    const isExpanded = expanded.has(v.versionId);
+                    const isActive = v.versionId === activeVersionId;
+                    return (
+                        <li key={v.versionId}>
+                            <button
+                                type="button"
+                                aria-expanded={isExpanded}
+                                onClick={() => toggleExpand(v.versionId)}
+                                className={cn(
+                                    'flex w-full items-center gap-2 px-4 py-2 text-left text-sm',
+                                    'hover:bg-accent/50 focus-visible:bg-accent/50 focus-visible:outline-none',
+                                )}
+                            >
+                                <ChevronRight
+                                    className={cn(
+                                        'size-3.5 shrink-0 text-muted-foreground transition-transform',
+                                        isExpanded && 'rotate-90',
+                                    )}
+                                />
+                                <span
+                                    className="w-20 shrink-0 font-mono text-muted-foreground text-xs"
+                                    title={formatFullTimestamp(v.timestamp)}
+                                >
+                                    {formatTime(v.timestamp)}
+                                </span>
+                                <span className="shrink-0 font-mono text-xs">
+                                    {shortId(v.versionId)}
+                                </span>
+                                {isActive && (
+                                    <Badge variant="outline" className="ml-auto">
+                                        Active
+                                    </Badge>
+                                )}
+                            </button>
+
+                            {isExpanded && (
+                                <div className="space-y-2 bg-muted/30 px-4 pt-1 pb-3">
+                                    <VersionDetailRow label="Version">
+                                        <span className="break-all font-mono text-xs">
+                                            {v.versionId}
+                                        </span>
+                                        <CopyIconButton
+                                            value={v.versionId}
+                                            label="Copy version ID"
+                                            toastText="Version ID copied"
+                                        />
+                                    </VersionDetailRow>
+                                    <VersionDetailRow label="Committed">
+                                        <span className="font-mono text-xs">
+                                            {formatFullTimestamp(v.timestamp)}
+                                        </span>
+                                    </VersionDetailRow>
+                                    {v.commit != null && (
+                                        <VersionDetailRow label="Commit">
+                                            <GitCommit className="size-3.5 shrink-0 text-muted-foreground" />
+                                            <span className="break-all font-mono text-xs">
+                                                {shortId(v.commit.id)} — {v.commit.message}
+                                            </span>
+                                            <span className="shrink-0 text-muted-foreground text-xs">
+                                                by {v.commit.committer}
+                                            </span>
+                                        </VersionDetailRow>
+                                    )}
+                                    {!isActive && (
+                                        <div className="flex justify-end pt-1">
+                                            <Button
+                                                variant="primary"
+                                                size="sm"
+                                                onClick={() => setPendingVersion(v)}
+                                            >
+                                                <RotateCcw className="size-3.5" />
+                                                Set as Active
+                                            </Button>
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+                        </li>
+                    );
+                })}
+            </ul>
+
+            {hasNextPage && (
+                <div className="p-3 text-center">
+                    <Button
+                        variant="default"
+                        size="sm"
+                        disabled={isFetchingNextPage}
+                        onClick={() => fetchNextPage()}
+                    >
+                        {isFetchingNextPage ? 'Loading…' : 'Load more'}
+                    </Button>
+                </div>
+            )}
+
+            <ConfirmDialog
+                open={pendingVersion != null}
+                onOpenChange={open => {
+                    if (!open) setPendingVersion(undefined);
+                }}
+                variant="primary"
+                title="Set as active version?"
+                description={
+                    pendingVersion != null
+                        ? `Version ${shortId(pendingVersion.versionId)} (created ${formatFullTimestamp(pendingVersion.timestamp)}) will become the active version of '${nodeName}'. The node's current content will be replaced.`
+                        : ''
+                }
+                confirmLabel="Set as Active"
+                onConfirm={handleSetActive}
+            />
+        </div>
+    );
+};
+
+NodeVersionsTab.displayName = NODE_VERSIONS_TAB_NAME;

--- a/src/main/resources/assets/js/lib/api/versions.ts
+++ b/src/main/resources/assets/js/lib/api/versions.ts
@@ -1,0 +1,109 @@
+import {
+    infiniteQueryOptions,
+    useMutation,
+    useQueryClient,
+} from '@tanstack/react-query';
+import { getConfig } from '../config';
+import { apiFetch } from './client';
+
+//
+// * Types
+//
+
+export type NodeCommitEntry = {
+    id: string;
+    message: string;
+    committer: string;
+    timestamp: string;
+};
+
+export type NodeVersionEntry = {
+    versionId: string;
+    nodeId: string;
+    nodePath: string;
+    timestamp: string;
+    commitId?: string;
+    commit?: NodeCommitEntry | null;
+};
+
+export type VersionsResponse = {
+    total: number;
+    count: number;
+    cursor: string | null;
+    activeVersionId: string | null;
+    hits: NodeVersionEntry[];
+};
+
+export type VersionsParams = {
+    repoId: string;
+    branch: string;
+    key: string;
+    count?: number;
+};
+
+export type SetActiveVersionParams = {
+    repoId: string;
+    branch: string;
+    key: string;
+    versionId: string;
+};
+
+export type SetActiveVersionResult = {
+    key: string;
+    versionId: string;
+    active: boolean;
+};
+
+//
+// * Fetch
+//
+
+export function fetchVersions(
+    params: VersionsParams & { cursor?: string | null },
+): Promise<VersionsResponse> {
+    const { apiUris } = getConfig();
+    const queryParams: Record<string, string> = {
+        repoId: params.repoId,
+        branch: params.branch,
+        key: params.key,
+    };
+    if (params.cursor != null) queryParams.cursor = params.cursor;
+    if (params.count != null) queryParams.count = String(params.count);
+
+    return apiFetch<VersionsResponse>(apiUris.versions, { params: queryParams });
+}
+
+export function versionsInfiniteQueryOptions(params: VersionsParams) {
+    return infiniteQueryOptions({
+        queryKey: ['versions', params.repoId, params.branch, params.key, params.count ?? 25],
+        queryFn: ({ pageParam }) => fetchVersions({ ...params, cursor: pageParam }),
+        initialPageParam: null as string | null,
+        getNextPageParam: last =>
+            last.cursor != null && last.hits.length > 0 ? last.cursor : undefined,
+        retry: false,
+    });
+}
+
+//
+// * Mutations
+//
+
+export function setActiveVersion(params: SetActiveVersionParams): Promise<SetActiveVersionResult> {
+    const { apiUris } = getConfig();
+    return apiFetch<SetActiveVersionResult>(apiUris.versions, {
+        method: 'PUT',
+        body: params,
+    });
+}
+
+export function useSetActiveVersion() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: setActiveVersion,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['versions'] });
+            queryClient.invalidateQueries({ queryKey: ['node-detail'] });
+            queryClient.invalidateQueries({ queryKey: ['nodes'] });
+        },
+    });
+}

--- a/src/main/resources/assets/js/lib/config.ts
+++ b/src/main/resources/assets/js/lib/config.ts
@@ -20,6 +20,7 @@ export type DataKitConfig = {
         tasks: string;
         events: string;
         audit: string;
+        versions: string;
     };
     launcherUri: string;
     user: UserConfig | null;


### PR DESCRIPTION
## Changes

- Added `apis/versions/` API — `GET` lists versions with cursor-based pagination, per-page commit enrichment, and `activeVersionId`; `PUT` sets active version (type shim for `setActiveVersion` missing from `@enonic-types/lib-node@8.0.0-A3`)
- Added `lib/api/versions.ts` — `versionsInfiniteQueryOptions` using `useInfiniteQuery`, `useSetActiveVersion` mutation invalidating versions + node-detail + nodes queries
- Implemented `NodeVersionsTab` — expandable rows (collapsed: time + short id + Active badge; expanded: full id with copy, timestamp, optional commit info, Set-as-Active button with `ConfirmDialog`), load-more pagination, skeleton/empty/error states
- Integrated Versions tab into `NodeDetailPanel`; tab count badge via shared `useInfiniteQuery` (deduped by key)
- Made tabs adaptive — icons always visible, labels shown via `@[576px]` container query; panel resizable 320–900 px with drag handle, width persisted to `localStorage`, double-click to reset
- Fixed Properties and Metadata table value cells (`break-all` replaces truncation to eliminate horizontal overflow)
- Registered `audit` and `versions` in `main.yaml` API allow-list (both were missing, causing 404 for these APIs)

Closes #14

<sub>*Drafted with AI assistance*</sub>
